### PR TITLE
fix: use @classmethod for async_get_options_flow (HA 2024.3+ compat)

### DIFF
--- a/custom_components/ws_core/config_flow.py
+++ b/custom_components/ws_core/config_flow.py
@@ -327,9 +327,9 @@ def _convert_temp_to_c(val: float, imperial: bool) -> float:
 class WSStationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = CONFIG_VERSION
 
-    @staticmethod
-    def async_get_options_flow(config_entry: config_entries.ConfigEntry):
-        return WSStationOptionsFlowHandler(config_entry)
+    @classmethod
+    def async_get_options_flow(cls, config_entry: config_entries.ConfigEntry):
+        return WSStationOptionsFlowHandler()
 
     def __init__(self):
         self._data: dict[str, Any] = {}


### PR DESCRIPTION
## Problem

Clicking **Configure** on the Weather Station Core integration raises a `500 Internal Server Error` ("Config flow could not be loaded") on Home Assistant 2024.3+.

**Root cause:** `async_get_options_flow` was declared as `@staticmethod` and passed `config_entry` directly to the `WSStationOptionsFlowHandler` constructor:

```python
@staticmethod
def async_get_options_flow(config_entry):
    return WSStationOptionsFlowHandler(config_entry)
```

Since HA 2024.3, `OptionsFlow.__init__()` no longer accepts positional arguments. The framework injects `self.config_entry` automatically after the flow object is created. Passing `config_entry` to the constructor raises `TypeError`, which HA surfaces as a 500 error.

## Fix

```python
@classmethod
def async_get_options_flow(cls, config_entry):
    return WSStationOptionsFlowHandler()
```

`WSStationOptionsFlowHandler` already accesses `self.config_entry` (via `_get()`), which continues to work correctly since the framework sets it automatically.

## Test

Verified on Home Assistant 2026.5.2 — the Configure dialog opens normally after this change and a restart.