### PR TITLE
fix(v1.7.2): battery entity no longer auto-selected from unrelated devices

### DIFF
--- a/custom_components/ws_core/config_flow.py
+++ b/custom_components/ws_core/config_flow.py
@@ -219,7 +219,7 @@ def _guess_defaults(hass: HomeAssistant) -> dict[str, str]:
         SRC_LUX: ["ws_01_illuminance", "illuminance", "lux"],
         SRC_UV: ["ws_01_uv_index", "uv_index", "uv"],
         SRC_DEW_POINT: ["ws_01_dew_point", "dew_point"],
-        SRC_BATTERY: ["ws_01_battery", "battery"],
+        SRC_BATTERY: ["ws_01_battery", "ws90_battery", "wh90_battery"],
     }
 
     for k, subs in mapping.items():

--- a/custom_components/ws_core/manifest.json
+++ b/custom_components/ws_core/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/kmich/ha_ws_core/issues",
   "requirements": [],
-  "version": "1.7.1"
+  "version": "1.7.2"
 }


### PR DESCRIPTION
## Summary
- Fixes #21 — during setup the optional battery field was pre-filled with a battery entity from an unrelated device (phone, lock, etc.)
- Root cause: `_guess_defaults` used the generic substring `"battery"` which matched any HA entity containing that word
- Fix: narrowed `SRC_BATTERY` patterns to station-specific slugs only (`ws_01_battery`, `ws90_battery`, `wh90_battery`); stations without a battery sensor now get a blank field

## Test plan
- [ ] Run setup wizard on a HA instance that has non-weather-station battery entities — battery field should be blank
- [ ] Run setup wizard on a HA instance with `ws_01_battery` present — field should still auto-detect correctly
- [ ] Complete wizard without selecting a battery entity — should succeed without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)