### PR TITLE
fix: resolve blocking event-loop I/O and wrong wind_direction state_class (#29)

### DIFF
--- a/custom_components/ws_core/__init__.py
+++ b/custom_components/ws_core/__init__.py
@@ -146,9 +146,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Do NOT re-raise - a failed initial fetch must not block entry creation.
         # The 60s tick scheduler will retry all fetches automatically.
 
-    # Create a device for the station
+    # Create a device for the station.
+    # Use executor_job so that the manifest.json read does not block the HA
+    # event loop (HA logs "Detected blocking call to read_text" otherwise).
     dev_reg = dr.async_get(hass)
-    _manifest = json.loads((pathlib.Path(__file__).parent / "manifest.json").read_text(encoding="utf-8"))
+    _manifest_path = pathlib.Path(__file__).parent / "manifest.json"
+    _manifest_text = await hass.async_add_executor_job(_manifest_path.read_text, "utf-8")
+    _manifest = json.loads(_manifest_text)
     dev_reg.async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, entry.entry_id)},

--- a/custom_components/ws_core/coordinator.py
+++ b/custom_components/ws_core/coordinator.py
@@ -345,9 +345,24 @@ except ImportError:
 
 _LOGGER = logging.getLogger(__name__)
 
-_INTEGRATION_VERSION: str = _json.loads(
-    (_pathlib.Path(__file__).parent / "manifest.json").read_text(encoding="utf-8")
-).get("version", "unknown")
+# Read the integration version without blocking the HA event loop.
+# pathlib.read_text() is a synchronous I/O call; performing it at module-level
+# triggers HA's "Detected blocking call" warning because the module is first
+# imported inside async_setup_entry (i.e. within the event loop).  We therefore
+# read the file once in a thread-safe, non-blocking way: read_bytes() on the
+# manifest is tiny and fast, but we still use executor so the call is explicit.
+# The value is cached in a module-level variable after the first read.
+_INTEGRATION_VERSION: str = "unknown"
+
+
+def _load_integration_version() -> str:
+    """Return the version string from manifest.json (blocking, run via executor)."""
+    try:
+        return _json.loads(
+            (_pathlib.Path(__file__).parent / "manifest.json").read_bytes()
+        ).get("version", "unknown")
+    except Exception:  # noqa: BLE001
+        return "unknown"
 
 
 # ---------------------------------------------------------------------------
@@ -611,6 +626,11 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     # ------------------------------------------------------------------
 
     async def async_start(self) -> None:
+        # Resolve the integration version without blocking the event loop.
+        global _INTEGRATION_VERSION
+        if _INTEGRATION_VERSION == "unknown":
+            _INTEGRATION_VERSION = await self.hass.async_add_executor_job(_load_integration_version)
+
         # Load persistent learning state from HA storage
         from homeassistant.helpers.storage import Store
 

--- a/custom_components/ws_core/sensor.py
+++ b/custom_components/ws_core/sensor.py
@@ -259,7 +259,7 @@ SENSORS: list[WSSensorDescription] = [
         icon="mdi:compass",
         device_class=SensorDeviceClass.WIND_DIRECTION,
         native_unit="\u00b0",
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=SensorStateClass.MEASUREMENT_ANGLE,
     ),
     WSSensorDescription(
         key=KEY_NORM_RAIN_TOTAL_MM,


### PR DESCRIPTION
## Summary

- `coordinator.py` and `__init__.py` call `Path.read_text()` synchronously inside the HA event loop, causing "Detected blocking call to read_text" warnings on every restart
- `WS Wind Direction` sensor uses `state_class=MEASUREMENT` but `device_class=WIND_DIRECTION` requires `MEASUREMENT_ANGLE` since HA 2024.11, causing an "impossible considering device class" log warning

## Changes

- `custom_components/ws_core/coordinator.py`: `_INTEGRATION_VERSION` initialised to `"unknown"`, resolved lazily in `async_start()` via `hass.async_add_executor_job()` to keep I/O off the event loop
- `custom_components/ws_core/__init__.py`: manifest read in `async_setup_entry` wrapped with `await hass.async_add_executor_job(...)`
- `custom_components/ws_core/sensor.py`: `state_class` for `KEY_NORM_WIND_DIR_DEG` changed from `SensorStateClass.MEASUREMENT` to `SensorStateClass.MEASUREMENT_ANGLE`

Fixes #29