### PR TITLE
fix: rename notifications switch to Enable notifications and invert logic (#28)

### DIFF
--- a/custom_components/ws_core/manifest.json
+++ b/custom_components/ws_core/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/kmich/ha_ws_core/issues",
   "requirements": [],
-  "version": "1.8.4"
+  "version": "1.8.5"
 }

--- a/custom_components/ws_core/switch.py
+++ b/custom_components/ws_core/switch.py
@@ -78,6 +78,7 @@ class WSFeatureDesc:
     default: bool
     name: str
     icon: str
+    inverted: bool = False
 
 
 FEATURE_SWITCHES: tuple[WSFeatureDesc, ...] = (
@@ -189,12 +190,13 @@ FEATURE_SWITCHES: tuple[WSFeatureDesc, ...] = (
         name="Feature: Precipitation Nowcast",
         icon="mdi:weather-pouring",
     ),
-    # v1.8.4 (issue #20)
+    # v1.8.4 (issue #20) — inverted: ON means notifications enabled (suppress=False)
     WSFeatureDesc(
         conf_key=CONF_SUPPRESS_NOTIFICATIONS,
         default=DEFAULT_SUPPRESS_NOTIFICATIONS,
-        name="Setting: Suppress HA Notifications",
-        icon="mdi:bell-off",
+        name="Setting: Enable HA Notifications",
+        icon="mdi:bell",
+        inverted=True,
     ),
 )
 
@@ -329,12 +331,13 @@ class WSFeatureSwitch(SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Read current state from the config entry."""
-        return bool(
+        stored = bool(
             self._entry.options.get(
                 self._desc.conf_key,
                 self._entry.data.get(self._desc.conf_key, self._desc.default),
             )
         )
+        return (not stored) if self._desc.inverted else stored
 
     async def async_turn_on(self, **kwargs) -> None:
         """Enable the feature."""
@@ -347,5 +350,5 @@ class WSFeatureSwitch(SwitchEntity):
     async def _write(self, value: bool) -> None:
         """Persist value to entry.options (triggers reload via update listener)."""
         new_options = dict(self._entry.options)
-        new_options[self._desc.conf_key] = value
+        new_options[self._desc.conf_key] = (not value) if self._desc.inverted else value
         self.hass.config_entries.async_update_entry(self._entry, options=new_options)

--- a/custom_components/ws_core/translations/en.json
+++ b/custom_components/ws_core/translations/en.json
@@ -1037,7 +1037,7 @@
         "name": "Feature: Precipitation Nowcast"
       },
       "ws_suppress_notifications": {
-        "name": "Setting: Suppress HA Notifications"
+        "name": "Setting: Enable HA Notifications"
       }
     },
     "number": {

--- a/custom_components/ws_core/translations/fr.json
+++ b/custom_components/ws_core/translations/fr.json
@@ -1422,7 +1422,7 @@
         "name": "Fonction : Prévision immédiate des précipitations"
       },
       "ws_suppress_notifications": {
-        "name": "Réglage : Désactiver les notifications HA"
+        "name": "Réglage : Activer les notifications HA"
       }
     },
     "number": {


### PR DESCRIPTION
## Summary

- Renames the `ws_suppress_notifications` switch from "Suppress HA Notifications" to "Enable HA Notifications" (EN) / "Activer les notifications HA" (FR)
- Adds `inverted: bool = False` field to `WSFeatureDesc` — when `True`, the switch display is flipped but the stored config key is unchanged, so no user migration needed
- `WSFeatureSwitch.is_on` and `_write` now respect `inverted`: switch ON → `suppress_notifications=False` (notifications enabled), switch OFF → `suppress_notifications=True`
- Icon changed from `mdi:bell-off` to `mdi:bell`
- Bumps version to 1.8.5

Closes #28

## Test plan
- [ ] Toggle the switch ON → HA notifications should fire normally
- [ ] Toggle the switch OFF → HA notifications should be suppressed
- [ ] Existing installs with `suppress_notifications=True` (previously "suppressed" = switch was ON) will now correctly show switch as OFF after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)