### PR TITLE
feat(vigicrues): multi-station support + river name labels (v1.9.0)

### DIFF
--- a/custom_components/ws_core/config_flow.py
+++ b/custom_components/ws_core/config_flow.py
@@ -77,9 +77,8 @@ from .const import (
     CONF_THRESH_RAIN_RATE_MMPH,
     CONF_THRESH_WIND_GUST_MS,
     CONF_UNITS_MODE,
-    CONF_VIGICRUES_RIVER_NAME,
     CONF_VIGICRUES_STATION_CODE,
-    CONF_VIGICRUES_STATION_NAME,
+    CONF_VIGICRUES_STATIONS,
     CONF_WU_API_KEY,
     CONF_WU_INTERVAL_MIN,
     CONF_WU_STATION_ID,
@@ -1115,34 +1114,47 @@ class WSStationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     # Step 7h: Vigicrues station picker (v1.8.0)
     # ------------------------------------------------------------------
     async def async_step_vigicrues_station(self, user_input: dict[str, Any] | None = None):
-        """Let the user pick a specific hydrometric station or keep auto-detect."""
+        """Let the user pick one or more hydrometric stations (or keep auto-detect)."""
         if user_input is not None:
             back = await self._handle_back(user_input)
             if back:
                 return back
-            code = str(user_input.get(CONF_VIGICRUES_STATION_CODE, "")).strip()
-            self._data[CONF_VIGICRUES_STATION_CODE] = code
-            for opt in getattr(self, "_vigicrues_station_options", []):
-                if opt["value"] == code:
-                    self._data[CONF_VIGICRUES_STATION_NAME] = opt.get("_name", "")
-                    self._data[CONF_VIGICRUES_RIVER_NAME] = opt.get("_river", "")
-                    break
+            selected_codes: list[str] = user_input.get(CONF_VIGICRUES_STATIONS) or []
+            stations: list[dict[str, str]] = []
+            for code in selected_codes:
+                code = code.strip()
+                if not code:
+                    continue
+                for opt in getattr(self, "_vigicrues_station_options", []):
+                    if opt["value"] == code:
+                        stations.append({"code": code, "name": opt.get("_name", code), "river": opt.get("_river", "")})
+                        break
+            # Empty list means auto-detect nearest station
+            self._data[CONF_VIGICRUES_STATIONS] = stations
             return await self.async_step_alerts()
 
         lat = self._data.get(CONF_FORECAST_LAT) or getattr(self.hass.config, "latitude", 0.0) or 0.0
         lon = self._data.get(CONF_FORECAST_LON) or getattr(self.hass.config, "longitude", 0.0) or 0.0
         options = await _fetch_vigicrues_station_options(lat, lon)
         self._vigicrues_station_options = options
-        current_code = self._data.get(CONF_VIGICRUES_STATION_CODE, "")
+
+        # Pre-select previously chosen stations (migrate legacy single-code if needed)
+        existing: list[dict] = self._data.get(CONF_VIGICRUES_STATIONS) or []
+        if not existing:
+            legacy_code = (self._data.get(CONF_VIGICRUES_STATION_CODE) or "").strip()
+            if legacy_code:
+                existing = [{"code": legacy_code}]
+        current_codes = [s["code"] for s in existing if s.get("code")]
 
         return self._show_step(
             step_id="vigicrues_station",
             data_schema=vol.Schema(
                 {
-                    vol.Optional(CONF_VIGICRUES_STATION_CODE, default=current_code): selector.SelectSelector(
+                    vol.Optional(CONF_VIGICRUES_STATIONS, default=current_codes): selector.SelectSelector(
                         selector.SelectSelectorConfig(
                             options=[{"value": o["value"], "label": o["label"]} for o in options],
                             mode="dropdown",
+                            multiple=True,
                         )
                     ),
                 }
@@ -1735,16 +1747,21 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
         )
 
     async def async_step_vigicrues_station_opt(self, user_input: dict[str, Any] | None = None):
-        """Options flow: pick a Vigicrues hydrometric station or keep auto-detect."""
+        """Options flow: pick one or more Vigicrues hydrometric stations or keep auto-detect."""
         g = self._get
         if user_input is not None:
-            code = str(user_input.get(CONF_VIGICRUES_STATION_CODE, "")).strip()
-            self._opt[CONF_VIGICRUES_STATION_CODE] = code
-            for opt in getattr(self, "_vigicrues_station_options_opt", []):
-                if opt["value"] == code:
-                    self._opt[CONF_VIGICRUES_STATION_NAME] = opt.get("_name", "")
-                    self._opt[CONF_VIGICRUES_RIVER_NAME] = opt.get("_river", "")
-                    break
+            selected_codes: list[str] = user_input.get(CONF_VIGICRUES_STATIONS) or []
+            stations: list[dict[str, str]] = []
+            for code in selected_codes:
+                code = code.strip()
+                if not code:
+                    continue
+                for opt in getattr(self, "_vigicrues_station_options_opt", []):
+                    if opt["value"] == code:
+                        stations.append({"code": code, "name": opt.get("_name", code), "river": opt.get("_river", "")})
+                        break
+            # Empty list means auto-detect nearest station
+            self._opt[CONF_VIGICRUES_STATIONS] = stations
             return self.async_create_entry(title="", data=self._opt)
 
         lat = (
@@ -1761,16 +1778,26 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
         )
         options = await _fetch_vigicrues_station_options(lat, lon)
         self._vigicrues_station_options_opt = options
-        current_code = g(CONF_VIGICRUES_STATION_CODE, "")
+
+        # Pre-select previously chosen stations (migrate legacy single-code if needed)
+        existing: list[dict] = self._opt.get(CONF_VIGICRUES_STATIONS) or g(CONF_VIGICRUES_STATIONS, []) or []
+        if not existing:
+            legacy_code = (
+                self._opt.get(CONF_VIGICRUES_STATION_CODE) or g(CONF_VIGICRUES_STATION_CODE, "") or ""
+            ).strip()
+            if legacy_code:
+                existing = [{"code": legacy_code}]
+        current_codes = [s["code"] for s in existing if s.get("code")]
 
         return self.async_show_form(
             step_id="vigicrues_station_opt",
             data_schema=vol.Schema(
                 {
-                    vol.Optional(CONF_VIGICRUES_STATION_CODE, default=current_code): selector.SelectSelector(
+                    vol.Optional(CONF_VIGICRUES_STATIONS, default=current_codes): selector.SelectSelector(
                         selector.SelectSelectorConfig(
                             options=[{"value": o["value"], "label": o["label"]} for o in options],
                             mode="dropdown",
+                            multiple=True,
                         )
                     ),
                 }

--- a/custom_components/ws_core/const.py
+++ b/custom_components/ws_core/const.py
@@ -498,10 +498,16 @@ CONF_ENABLE_VIGICRUES = "enable_vigicrues"
 
 # ---------------------------------------------------------------------------
 # v1.8.0 - Vigicrues station picker (issue #13)
+# v1.9.0 - Multi-station support (issue #27)
 # ---------------------------------------------------------------------------
-CONF_VIGICRUES_STATION_CODE = "vigicrues_station_code"  # "" = auto-detect
-CONF_VIGICRUES_STATION_NAME = "vigicrues_station_name"  # cached for display
-CONF_VIGICRUES_RIVER_NAME = "vigicrues_river_name"  # cached for display
+CONF_VIGICRUES_STATION_CODE = "vigicrues_station_code"  # legacy single-station (kept for migration)
+CONF_VIGICRUES_STATION_NAME = "vigicrues_station_name"  # legacy (kept for migration)
+CONF_VIGICRUES_RIVER_NAME = "vigicrues_river_name"  # legacy (kept for migration)
+
+# v1.9.0: replaces the three legacy keys above.  Stored as a list of dicts:
+#   [{"code": "V123456", "name": "Station libellé", "river": "La Seine"}, ...]
+# An empty list means auto-detect the nearest station.
+CONF_VIGICRUES_STATIONS = "vigicrues_stations"
 
 # Defaults
 DEFAULT_ENABLE_VIGILANCE_METEO = False
@@ -514,6 +520,8 @@ KEY_VIGILANCE_MAX_LEVEL = "vigilance_max_level"  # overall worst: vert/jaune/ora
 KEY_FIRE_DANGER_VIGILANCE = "fire_danger_vigilance"
 
 # Data keys - Vigicrues (real-time river level via Hub'Eau v2)
+# v1.9.0: per-station key pattern is f"river_level_m_{code}" where code is the
+# Hub'Eau station code (e.g. "V123456").  KEY_RIVER_LEVEL_M kept for compat.
 KEY_RIVER_LEVEL_M = "river_level_m"
 
 # ---------------------------------------------------------------------------

--- a/custom_components/ws_core/coordinator.py
+++ b/custom_components/ws_core/coordinator.py
@@ -142,6 +142,7 @@ from .const import (
     CONF_VIGICRUES_RIVER_NAME,
     CONF_VIGICRUES_STATION_CODE,
     CONF_VIGICRUES_STATION_NAME,
+    CONF_VIGICRUES_STATIONS,
     CONF_WU_API_KEY,
     CONF_WU_INTERVAL_MIN,
     CONF_WU_STATION_ID,
@@ -276,7 +277,6 @@ from .const import (
     KEY_RAIN_PROBABILITY_COMBINED,
     KEY_RAIN_RATE_FILT,
     KEY_RAIN_TODAY_MM,
-    KEY_RIVER_LEVEL_M,
     KEY_SEA_LEVEL_PRESSURE_HPA,
     KEY_SEA_SURFACE_TEMP,
     KEY_SENSOR_DRIFT_FLAGS,
@@ -524,13 +524,29 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._vigilance_cache: dict[str, Any] | None = None
 
         self.vigicrues_enabled = bool(_get(CONF_ENABLE_VIGICRUES, DEFAULT_ENABLE_VIGICRUES))
-        self._vigicrues_cache: dict[str, Any] | None = None
-        _conf_code = (_get(CONF_VIGICRUES_STATION_CODE, "") or "").strip()
-        self._vigicrues_station_code: str | None = _conf_code if _conf_code else None
-        self._vigicrues_station_name: str | None = (
-            (_get(CONF_VIGICRUES_STATION_NAME, "") or None) if _conf_code else None
-        )
-        self._vigicrues_river_name: str | None = (_get(CONF_VIGICRUES_RIVER_NAME, "") or None) if _conf_code else None
+
+        # v1.9.0: multi-station.  Load from CONF_VIGICRUES_STATIONS (list of
+        # {code, name, river} dicts); fall back to legacy single-station keys.
+        _new_stations: list[dict[str, str]] = list(_get(CONF_VIGICRUES_STATIONS, []) or [])
+        if not _new_stations:
+            _conf_code = (_get(CONF_VIGICRUES_STATION_CODE, "") or "").strip()
+            if _conf_code:
+                _new_stations = [
+                    {
+                        "code": _conf_code,
+                        "name": (_get(CONF_VIGICRUES_STATION_NAME, "") or _conf_code),
+                        "river": (_get(CONF_VIGICRUES_RIVER_NAME, "") or ""),
+                    }
+                ]
+        # Each entry: {"code": str, "name": str, "river": str}
+        # Empty list means auto-detect nearest station.
+        self._vigicrues_stations: list[dict[str, str]] = _new_stations
+        # Per-station caches keyed by station code (or "" for auto-detected)
+        self._vigicrues_caches: dict[str, dict[str, Any]] = {}
+        # For auto-detect mode, remember the discovered code across fetches
+        self._vigicrues_auto_code: str | None = None
+        self._vigicrues_auto_name: str | None = None
+        self._vigicrues_auto_river: str | None = None
 
         # v1.7.0 Precipitation nowcast (Open-Meteo minutely_15, independent of provider)
         self.nowcast_enabled = bool(_get(CONF_ENABLE_NOWCAST, DEFAULT_ENABLE_NOWCAST))
@@ -2281,14 +2297,17 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     break
             data[KEY_FIRE_DANGER_VIGILANCE] = fire_color if fire_color else "vert"
 
-        # v1.6.0 - Vigicrues (France only, no API key)
-        if self.vigicrues_enabled and self._vigicrues_cache:
-            vr = self._vigicrues_cache
-            data[KEY_RIVER_LEVEL_M] = vr.get("level_m")
-            data["_river_station_name"] = vr.get("station_name")
-            data["_river_name"] = vr.get("river_name")
-            data["_river_obs_time"] = vr.get("obs_time")
-            data["_river_station_code"] = vr.get("station_code")
+        # v1.9.0 - Vigicrues multi-station (France only, no API key)
+        if self.vigicrues_enabled and self._vigicrues_caches:
+            # Expose auto-detected code so WSRiverSensor can resolve it
+            if self._vigicrues_auto_code:
+                data["_vigicrues_auto_code"] = self._vigicrues_auto_code
+            for code, vr in self._vigicrues_caches.items():
+                data[f"river_level_m_{code}"] = vr.get("level_m")
+                data[f"_river_station_name_{code}"] = vr.get("station_name")
+                data[f"_river_name_{code}"] = vr.get("river_name")
+                data[f"_river_obs_time_{code}"] = vr.get("obs_time")
+                data[f"_river_station_code_{code}"] = vr.get("station_code")
 
         # v1.7.0 - Precipitation nowcast (Open-Meteo minutely_15)
         if self.nowcast_enabled and self._nowcast_cache:
@@ -3086,68 +3105,101 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         await self.async_request_refresh()
 
     # ------------------------------------------------------------------
-    # v1.6.0 - Vigicrues (Hub'Eau v2, France, no key)
+    # v1.9.0 - Vigicrues multi-station (Hub'Eau v2, France, no key)
     # ------------------------------------------------------------------
 
     async def _async_fetch_vigicrues(self) -> None:
-        """Fetch real-time water level from the nearest Hub'Eau hydrometric station.
+        """Fetch real-time water level for all configured Vigicrues stations.
 
-        Two-step:
-          1. Find nearest active station within 50 km (cached after first successful lookup)
-          2. Fetch latest H-observation (water level in mm; stored as m for display)
+        If no stations are configured (auto-detect mode), finds the nearest
+        active station within 50 km and monitors it.
         """
-        if not (self.forecast_lat is not None and self.forecast_lon is not None):
+        if self.forecast_lat is None or self.forecast_lon is None:
             return
 
-        lat = self.forecast_lat
-        lon = self.forecast_lon
+        stations = list(self._vigicrues_stations)  # configured stations
+        need_refresh = False
 
         try:
             async with aiohttp.ClientSession() as session:
-                # Step 1: find nearest station (only if not yet cached)
-                if not self._vigicrues_station_code:
-                    stations_url = (
-                        "https://hubeau.eaufrance.fr/api/v2/hydrometrie/referentiel/stations"
-                        f"?format=json&longitude={lon}&latitude={lat}&distance=50"
-                        "&en_service=true&size=1"
-                        "&fields=code_station,libelle_station,longitude_station,latitude_station"
-                        ",code_cours_eau,libelle_cours_eau"
-                    )
-                    async with session.get(stations_url, timeout=aiohttp.ClientTimeout(total=15)) as resp:
-                        if resp.status != 200:
-                            _LOGGER.warning("ws_core Vigicrues: station lookup HTTP %s", resp.status)
+                # Auto-detect mode: no stations configured → find nearest
+                if not stations:
+                    if not self._vigicrues_auto_code:
+                        lat, lon = self.forecast_lat, self.forecast_lon
+                        url = (
+                            "https://hubeau.eaufrance.fr/api/v2/hydrometrie/referentiel/stations"
+                            f"?format=json&longitude={lon}&latitude={lat}&distance=50"
+                            "&en_service=true&size=1"
+                            "&fields=code_station,libelle_station,libelle_cours_eau"
+                        )
+                        async with session.get(url, timeout=aiohttp.ClientTimeout(total=15)) as resp:
+                            if resp.status != 200:
+                                _LOGGER.warning("ws_core Vigicrues: auto-detect HTTP %s", resp.status)
+                                return
+                            sdata = await resp.json()
+                        found = sdata.get("data", [])
+                        if not found:
+                            _LOGGER.debug("ws_core Vigicrues: no station within 50 km (outside France?)")
                             return
-                        sdata = await resp.json()
-                    stations = sdata.get("data", [])
-                    if not stations:
-                        _LOGGER.debug("ws_core Vigicrues: no station found within 50 km (not in France?)")
-                        return
-                    st = stations[0]
-                    self._vigicrues_station_code = st.get("code_station")
-                    self._vigicrues_station_name = st.get("libelle_station") or self._vigicrues_station_code
-                    self._vigicrues_river_name = st.get("libelle_cours_eau") or ""
-                    _LOGGER.debug(
-                        "ws_core Vigicrues: nearest station %s (%s) on %s",
-                        self._vigicrues_station_code,
-                        self._vigicrues_station_name,
-                        self._vigicrues_river_name,
+                        st = found[0]
+                        self._vigicrues_auto_code = st.get("code_station", "")
+                        self._vigicrues_auto_name = st.get("libelle_station") or self._vigicrues_auto_code
+                        self._vigicrues_auto_river = st.get("libelle_cours_eau") or ""
+                        _LOGGER.debug(
+                            "ws_core Vigicrues auto-detected: %s (%s) on %s",
+                            self._vigicrues_auto_code,
+                            self._vigicrues_auto_name,
+                            self._vigicrues_auto_river,
+                        )
+                    stations = [
+                        {
+                            "code": self._vigicrues_auto_code or "",
+                            "name": self._vigicrues_auto_name or "",
+                            "river": self._vigicrues_auto_river or "",
+                        }
+                    ]
+
+                for st_info in stations:
+                    code = st_info.get("code", "").strip()
+                    if not code:
+                        continue
+                    obs_url = (
+                        "https://hubeau.eaufrance.fr/api/v2/hydrometrie/observations_tr"
+                        f"?format=json&code_entite={code}"
+                        "&grandeur_hydro=H&size=1"
+                        "&fields=code_station,date_obs,resultat_obs"
                     )
+                    async with session.get(obs_url, timeout=aiohttp.ClientTimeout(total=15)) as resp:
+                        if resp.status not in (200, 206):
+                            _LOGGER.warning("ws_core Vigicrues: observations HTTP %s for %s", resp.status, code)
+                            continue
+                        odata = await resp.json()
 
-                if not self._vigicrues_station_code:
-                    return
+                    observations = odata.get("data", [])
+                    if not observations:
+                        _LOGGER.debug("ws_core Vigicrues: no observations for station %s", code)
+                        continue
 
-                # Step 2: fetch latest water level (grandeur_hydro=H)
-                obs_url = (
-                    "https://hubeau.eaufrance.fr/api/v2/hydrometrie/observations_tr"
-                    f"?format=json&code_entite={self._vigicrues_station_code}"
-                    "&grandeur_hydro=H&size=1"
-                    "&fields=code_station,date_obs,resultat_obs"
-                )
-                async with session.get(obs_url, timeout=aiohttp.ClientTimeout(total=15)) as resp:
-                    if resp.status != 200:
-                        _LOGGER.warning("ws_core Vigicrues: observations HTTP %s", resp.status)
-                        return
-                    odata = await resp.json()
+                    obs = observations[0]
+                    raw_mm = obs.get("resultat_obs")
+                    level_m = round(float(raw_mm) / 1000.0, 3) if raw_mm is not None else None
+
+                    self._vigicrues_caches[code] = {
+                        "level_m": level_m,
+                        "station_code": code,
+                        "station_name": st_info.get("name", code),
+                        "river_name": st_info.get("river", ""),
+                        "obs_time": obs.get("date_obs"),
+                        "fetched_at": dt_util.utcnow().isoformat(),
+                    }
+                    _LOGGER.debug(
+                        "ws_core Vigicrues: %s (%s) level=%.3f m at %s",
+                        st_info.get("name", code),
+                        code,
+                        level_m or 0,
+                        obs.get("date_obs"),
+                    )
+                    need_refresh = True
 
         except (aiohttp.ClientError, TimeoutError, ValueError) as exc:
             _LOGGER.warning("ws_core Vigicrues fetch error: %s", exc)
@@ -3156,27 +3208,5 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _LOGGER.error("ws_core Vigicrues unexpected error: %s", exc, exc_info=True)
             return
 
-        observations = odata.get("data", [])
-        if not observations:
-            _LOGGER.debug("ws_core Vigicrues: no observations for station %s", self._vigicrues_station_code)
-            return
-
-        obs = observations[0]
-        raw_mm = obs.get("resultat_obs")  # Hub'Eau returns mm for H
-        level_m = round(float(raw_mm) / 1000.0, 3) if raw_mm is not None else None
-
-        self._vigicrues_cache = {
-            "level_m": level_m,
-            "station_code": self._vigicrues_station_code,
-            "station_name": self._vigicrues_station_name,
-            "river_name": self._vigicrues_river_name,
-            "obs_time": obs.get("date_obs"),
-            "fetched_at": dt_util.utcnow().isoformat(),
-        }
-        _LOGGER.debug(
-            "ws_core Vigicrues: %s level=%.3f m at %s",
-            self._vigicrues_station_name,
-            level_m or 0,
-            obs.get("date_obs"),
-        )
-        await self.async_request_refresh()
+        if need_refresh:
+            await self.async_request_refresh()

--- a/custom_components/ws_core/diagnostics.py
+++ b/custom_components/ws_core/diagnostics.py
@@ -56,7 +56,7 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigE
 
     return {
         "title": entry.title,
-        "version": "1.8.5",
+        "version": "1.9.0",
         "entry_data": _redact_coords(dict(entry.data)),
         "entry_options": _redact_coords(dict(entry.options)),
         "sources": sources,

--- a/custom_components/ws_core/manifest.json
+++ b/custom_components/ws_core/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/kmich/ha_ws_core/issues",
   "requirements": [],
-  "version": "1.8.5"
+  "version": "1.9.0"
 }

--- a/custom_components/ws_core/sensor.py
+++ b/custom_components/ws_core/sensor.py
@@ -42,6 +42,10 @@ from .const import (
     # v1.6.0
     CONF_ENABLE_VIGILANCE_METEO,
     CONF_PREFIX,
+    CONF_VIGICRUES_RIVER_NAME,
+    CONF_VIGICRUES_STATION_CODE,
+    CONF_VIGICRUES_STATION_NAME,
+    CONF_VIGICRUES_STATIONS,
     DEFAULT_PREFIX,
     DOMAIN,
     # v1.5.0
@@ -128,7 +132,6 @@ from .const import (
     KEY_RAIN_PROBABILITY_COMBINED,
     KEY_RAIN_RATE_FILT,
     KEY_RAIN_TODAY_MM,
-    KEY_RIVER_LEVEL_M,
     KEY_SEA_LEVEL_PRESSURE_HPA,
     KEY_SEA_SURFACE_TEMP,
     KEY_SENSOR_DRIFT_FLAGS,
@@ -584,21 +587,8 @@ SENSORS: list[WSSensorDescription] = [
             "fetched_at": d.get("_vigilance_fetched_at"),
         },
     ),
-    # Vigicrues - real-time water level at nearest hydrometric station
-    WSSensorDescription(
-        key=KEY_RIVER_LEVEL_M,
-        translation_key="river_level",
-        name="WS River Level",
-        icon="mdi:waves",
-        native_unit="m",
-        state_class=SensorStateClass.MEASUREMENT,
-        attrs_fn=lambda d: {
-            "station": d.get("_river_station_name"),
-            "river": d.get("_river_name"),
-            "station_code": d.get("_river_station_code"),
-            "observed_at": d.get("_river_obs_time"),
-        },
-    ),
+    # Vigicrues: sensors are created dynamically per station in async_setup_entry
+    # (v1.9.0 multi-station). No static WSSensorDescription here.
     # v1.7.0 - Precipitation nowcast (Open-Meteo minutely_15)
     WSSensorDescription(
         key=KEY_RAIN_NEXT_60MIN,
@@ -1450,7 +1440,7 @@ _FEATURE_TOGGLE_MAP: dict[str, str] = {
     # v1.6.0 French regional
     KEY_VIGILANCE_MAX_LEVEL: CONF_ENABLE_VIGILANCE_METEO,
     KEY_FIRE_DANGER_VIGILANCE: CONF_ENABLE_VIGILANCE_METEO,
-    KEY_RIVER_LEVEL_M: CONF_ENABLE_VIGICRUES,
+    # KEY_RIVER_LEVEL_M: handled dynamically in async_setup_entry (multi-station)
     # v1.6.2 - station diagnostics (opt-in)
     KEY_SENSOR_DRIFT_FLAGS: CONF_ENABLE_DIAGNOSTICS,
     KEY_CONSISTENCY_FLAGS: CONF_ENABLE_DIAGNOSTICS,
@@ -1484,7 +1474,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             continue
         filtered.append(desc)
 
-    entities: list[WSSensor] = [WSSensor(coordinator, entry, desc, prefix) for desc in filtered]
+    entities: list[SensorEntity] = [WSSensor(coordinator, entry, desc, prefix) for desc in filtered]
+
+    # v1.9.0: dynamic Vigicrues river sensors — one per configured station
+    if opts.get(CONF_ENABLE_VIGICRUES, False):
+        stations: list[dict] = list(opts.get(CONF_VIGICRUES_STATIONS) or [])
+        if not stations:
+            # Migrate legacy single-station config
+            code = (opts.get(CONF_VIGICRUES_STATION_CODE) or "").strip()
+            if code:
+                stations = [
+                    {
+                        "code": code,
+                        "name": opts.get(CONF_VIGICRUES_STATION_NAME) or code,
+                        "river": opts.get(CONF_VIGICRUES_RIVER_NAME) or "",
+                    }
+                ]
+            else:
+                # Auto-detect — use a placeholder; the coordinator will fill the name
+                stations = [{"code": "", "name": "", "river": ""}]
+        for st in stations:
+            entities.append(WSRiverSensor(coordinator, entry, prefix, st))
+
     async_add_entities(entities)
 
 
@@ -1671,7 +1682,7 @@ class WSSensor(RestoreEntity, CoordinatorEntity, SensorEntity):
             KEY_CLEARNESS_INDEX: "clearness_index",
             KEY_CLOUD_COVER_PCT: "cloud_cover",
             KEY_VIGILANCE_MAX_LEVEL: "vigilance",
-            KEY_RIVER_LEVEL_M: "river_level",
+            # river_level slugs are handled in WSRiverSensor directly
             KEY_RAIN_NEXT_60MIN: "rain_next_60min",
             KEY_MINUTES_UNTIL_RAIN: "minutes_until_rain",
             KEY_MINUTES_UNTIL_DRY: "minutes_until_dry",
@@ -1733,3 +1744,91 @@ class WSSensor(RestoreEntity, CoordinatorEntity, SensorEntity):
                 "alert_state": d.get(KEY_ALERT_STATE),
             }
         return {}
+
+
+# ---------------------------------------------------------------------------
+# v1.9.0 - Dynamic river-level sensor (one per Vigicrues station)
+# ---------------------------------------------------------------------------
+
+
+class WSRiverSensor(CoordinatorEntity, SensorEntity):
+    """Real-time water level for a single Vigicrues hydrometric station.
+
+    One entity is created per configured station.  The station code is used as
+    part of the unique_id; the river name (once known) is embedded in the entity
+    name so users can tell stations apart at a glance.
+    """
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:waves"
+    _attr_native_unit_of_measurement = "m"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_device_class = None
+
+    def __init__(
+        self,
+        coordinator,
+        entry: ConfigEntry,
+        prefix: str,
+        station: dict,
+    ) -> None:
+        super().__init__(coordinator)
+        self._entry = entry
+        self._prefix = prefix
+        # station dict: {code, name, river} — code may be "" for auto-detect
+        self._station_code: str = (station.get("code") or "").strip()
+        self._station_name: str = station.get("name") or self._station_code
+        self._river_name: str = station.get("river") or ""
+
+        # Unique ID uses station code; fall back to "auto" for auto-detect mode
+        uid_suffix = self._station_code if self._station_code else "auto"
+        self._attr_unique_id = f"{entry.entry_id}_river_level_{uid_suffix}"
+        slug = f"river_level_{uid_suffix}" if uid_suffix != "auto" else "river_level"
+        self._attr_suggested_object_id = f"{prefix}_{slug}"
+
+    @property
+    def _cache_key(self) -> str:
+        """Coordinator data key prefix for this station."""
+        code = self._station_code
+        if not code:
+            # Auto-detect: use whatever code the coordinator resolved
+            code = (self.coordinator.data or {}).get("_vigicrues_auto_code", "")
+        return code
+
+    def _resolved_code(self) -> str:
+        """Return the actual station code (resolved for auto-detect)."""
+        if self._station_code:
+            return self._station_code
+        return (self.coordinator.data or {}).get("_vigicrues_auto_code", "")
+
+    @property
+    def name(self) -> str:
+        """River name + level, updated once the coordinator has the metadata."""
+        d = self.coordinator.data or {}
+        code = self._resolved_code()
+        river = d.get(f"_river_name_{code}") or self._river_name
+        if river:
+            return f"WS River Level — {river}"
+        station = d.get(f"_river_station_name_{code}") or self._station_name
+        return f"WS River Level — {station}" if station else "WS River Level"
+
+    @property
+    def native_value(self):
+        d = self.coordinator.data or {}
+        code = self._resolved_code()
+        return d.get(f"river_level_m_{code}")
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        d = self.coordinator.data or {}
+        code = self._resolved_code()
+        return {
+            "station": d.get(f"_river_station_name_{code}") or self._station_name,
+            "river": d.get(f"_river_name_{code}") or self._river_name,
+            "station_code": d.get(f"_river_station_code_{code}") or code,
+            "observed_at": d.get(f"_river_obs_time_{code}"),
+        }
+
+    @property
+    def device_info(self) -> dict:
+        return {"identifiers": {(DOMAIN, self._entry.entry_id)}}

--- a/custom_components/ws_core/strings.json
+++ b/custom_components/ws_core/strings.json
@@ -163,14 +163,14 @@
         }
       },
       "vigicrues_station": {
-        "title": "Vigicrues station",
-        "description": "Choose a hydrometric station or leave on 'Auto' to use the nearest one.",
+        "title": "Vigicrues stations",
+        "description": "Choose one or more hydrometric stations, or leave empty to auto-detect the nearest one.",
         "data": {
-          "vigicrues_station_code": "Hydrometric station",
+          "vigicrues_stations": "Hydrometric stations",
           "_go_back": "← Go back to previous step"
         },
         "data_description": {
-          "vigicrues_station_code": "Select a station or leave on 'Auto (nearest station)' to auto-detect."
+          "vigicrues_stations": "Select one or more stations. Leave empty to auto-detect the nearest station."
         }
       }
     },
@@ -350,13 +350,13 @@
         }
       },
       "vigicrues_station_opt": {
-        "title": "Vigicrues station",
-        "description": "Choose a hydrometric station or leave on 'Auto' to use the nearest one.",
+        "title": "Vigicrues stations",
+        "description": "Choose one or more hydrometric stations, or leave empty to auto-detect the nearest one.",
         "data": {
-          "vigicrues_station_code": "Hydrometric station"
+          "vigicrues_stations": "Hydrometric stations"
         },
         "data_description": {
-          "vigicrues_station_code": "Select a station or leave on 'Auto (nearest station)' to auto-detect."
+          "vigicrues_stations": "Select one or more stations. Leave empty to auto-detect the nearest station."
         }
       }
     },

--- a/custom_components/ws_core/translations/en.json
+++ b/custom_components/ws_core/translations/en.json
@@ -163,14 +163,14 @@
         }
       },
       "vigicrues_station": {
-        "title": "Vigicrues station",
-        "description": "Choose a hydrometric station or leave on 'Auto' to use the nearest one.",
+        "title": "Vigicrues stations",
+        "description": "Choose one or more hydrometric stations, or leave empty to auto-detect the nearest one.",
         "data": {
-          "vigicrues_station_code": "Hydrometric station",
+          "vigicrues_stations": "Hydrometric stations",
           "_go_back": "← Go back to previous step"
         },
         "data_description": {
-          "vigicrues_station_code": "Select a station or leave on 'Auto (nearest station)' to auto-detect."
+          "vigicrues_stations": "Select one or more stations. Leave empty to auto-detect the nearest station."
         }
       }
     },
@@ -350,13 +350,13 @@
         }
       },
       "vigicrues_station_opt": {
-        "title": "Vigicrues station",
-        "description": "Choose a hydrometric station or leave on 'Auto' to use the nearest one.",
+        "title": "Vigicrues stations",
+        "description": "Choose one or more hydrometric stations, or leave empty to auto-detect the nearest one.",
         "data": {
-          "vigicrues_station_code": "Hydrometric station"
+          "vigicrues_stations": "Hydrometric stations"
         },
         "data_description": {
-          "vigicrues_station_code": "Select a station or leave on 'Auto (nearest station)' to auto-detect."
+          "vigicrues_stations": "Select one or more stations. Leave empty to auto-detect the nearest station."
         }
       }
     },

--- a/custom_components/ws_core/translations/fr.json
+++ b/custom_components/ws_core/translations/fr.json
@@ -163,14 +163,14 @@
         }
       },
       "vigicrues_station": {
-        "title": "Station Vigicrues",
-        "description": "Choisissez une station hydrométrique ou laissez sur « Auto » pour utiliser la plus proche.",
+        "title": "Stations Vigicrues",
+        "description": "Choisissez une ou plusieurs stations hydrométriques, ou laissez vide pour détecter automatiquement la plus proche.",
         "data": {
-          "vigicrues_station_code": "Station hydrométrique",
+          "vigicrues_stations": "Stations hydrométriques",
           "_go_back": "← Retour à l'étape précédente"
         },
         "data_description": {
-          "vigicrues_station_code": "Sélectionnez une station ou laissez sur « Auto (station la plus proche) » pour la détection automatique."
+          "vigicrues_stations": "Sélectionnez une ou plusieurs stations. Laissez vide pour la détection automatique de la station la plus proche."
         }
       }
     },
@@ -350,13 +350,13 @@
         }
       },
       "vigicrues_station_opt": {
-        "title": "Station Vigicrues",
-        "description": "Choisissez une station hydrométrique ou laissez sur « Auto » pour utiliser la plus proche.",
+        "title": "Stations Vigicrues",
+        "description": "Choisissez une ou plusieurs stations hydrométriques, ou laissez vide pour détecter automatiquement la plus proche.",
         "data": {
-          "vigicrues_station_code": "Station hydrométrique"
+          "vigicrues_stations": "Stations hydrométriques"
         },
         "data_description": {
-          "vigicrues_station_code": "Sélectionnez une station ou laissez sur « Auto (station la plus proche) » pour la détection automatique."
+          "vigicrues_stations": "Sélectionnez une ou plusieurs stations. Laissez vide pour la détection automatique de la station la plus proche."
         }
       }
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha_ws_core"
-version = "1.8.5"
+version = "1.9.0"
 description = "Weather Station Core - Home Assistant integration for personal weather stations"
 requires-python = ">=3.12"
 

--- a/scripts/validate_dashboard_entities.py
+++ b/scripts/validate_dashboard_entities.py
@@ -72,6 +72,8 @@ KNOWN_EXTERNAL: set[str] = {
     "input_text.weather_station_location",
     "input_text.weather_lightning_sensor",
     "sensor.iopool_lagonisi_temperature",
+    # WSRiverSensor (dynamic, auto-detect): suggested_object_id = "{prefix}_river_level"
+    "sensor.ws_river_level",
 }
 
 


### PR DESCRIPTION
## Summary

- **Multi-station Vigicrues**: users can now select multiple hydrometric stations (or leave empty for auto-detect nearest within 50 km)
- **River name in labels**: `WSRiverSensor` entity name shows river name or station name dynamically from coordinator data
- **Per-station data keys**: coordinator writes `river_level_m_{code}`, `_river_name_{code}`, etc. — backward-compatible with legacy single-station config
- **Legacy migration**: existing installs with `CONF_VIGICRUES_STATION_CODE` are silently migrated to the new `CONF_VIGICRUES_STATIONS` list format
- **Hub'Eau 206**: fixed status check to accept HTTP 206 (partial content) as valid response

Closes #27

## Test plan
- [ ] Fresh install: Vigicrues station step shows multi-select dropdown; selecting 0 stations → auto-detect; selecting N → N river sensors created
- [ ] Existing install (legacy single code): reopening options flow pre-selects the old station; saving creates one `WSRiverSensor`
- [ ] Entity names include river name when available
- [ ] `ruff check` and `ruff format` pass (verified locally)
- [ ] Version consistency check: manifest / diagnostics / pyproject all at 1.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)