### PR TITLE
feat: provider API links in config flow + Vigicrues flow sensor

### DIFF
--- a/custom_components/ws_core/config_flow.py
+++ b/custom_components/ws_core/config_flow.py
@@ -718,7 +718,13 @@ class WSStationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             FORECAST_PROVIDER_PIRATE: "Pirate Weather",
             FORECAST_PROVIDER_METEO_FRANCE: "Météo France",
         }
+        provider_api_urls = {
+            FORECAST_PROVIDER_OWM: "https://openweathermap.org/api",
+            FORECAST_PROVIDER_PIRATE: "https://pirateweather.net/en/latest/",
+            FORECAST_PROVIDER_METEO_FRANCE: "https://portail-api.meteofrance.fr/",
+        }
         provider_name = provider_labels.get(provider, provider)
+        api_url = provider_api_urls.get(provider, "")
 
         return self._show_step(
             step_id="forecast_api_key",
@@ -731,7 +737,7 @@ class WSStationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Optional("_go_back", default=False): selector.BooleanSelector(),
                 }
             ),
-            description_placeholders={"provider_name": provider_name},
+            description_placeholders={"provider_name": provider_name, "api_url": api_url},
             last_step=False,
         )
 
@@ -1486,7 +1492,13 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
             FORECAST_PROVIDER_PIRATE: "Pirate Weather",
             FORECAST_PROVIDER_METEO_FRANCE: "Météo France",
         }
+        provider_api_urls = {
+            FORECAST_PROVIDER_OWM: "https://openweathermap.org/api",
+            FORECAST_PROVIDER_PIRATE: "https://pirateweather.net/en/latest/",
+            FORECAST_PROVIDER_METEO_FRANCE: "https://portail-api.meteofrance.fr/",
+        }
         provider_name = provider_labels.get(provider, provider)
+        api_url = provider_api_urls.get(provider, "")
         current_key = self._opt.get(CONF_FORECAST_API_KEY, self._get(CONF_FORECAST_API_KEY, ""))
 
         return self.async_show_form(
@@ -1498,7 +1510,7 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
                     ),
                 }
             ),
-            description_placeholders={"provider_name": provider_name},
+            description_placeholders={"provider_name": provider_name, "api_url": api_url},
         )
 
     # ------------------------------------------------------------------

--- a/custom_components/ws_core/coordinator.py
+++ b/custom_components/ws_core/coordinator.py
@@ -2307,9 +2307,11 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 data["_vigicrues_auto_code"] = self._vigicrues_auto_code
             for code, vr in self._vigicrues_caches.items():
                 data[f"river_level_m_{code}"] = vr.get("level_m")
+                data[f"river_flow_m3s_{code}"] = vr.get("flow_m3s")
                 data[f"_river_station_name_{code}"] = vr.get("station_name")
                 data[f"_river_name_{code}"] = vr.get("river_name")
                 data[f"_river_obs_time_{code}"] = vr.get("obs_time")
+                data[f"_river_flow_obs_time_{code}"] = vr.get("flow_obs_time")
                 data[f"_river_station_code_{code}"] = vr.get("station_code")
 
         # v1.7.0 - Precipitation nowcast (Open-Meteo minutely_15)
@@ -3206,6 +3208,32 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         level_m or 0,
                         obs.get("date_obs"),
                     )
+
+                    # Try to fetch flow data (Q) — not all stations provide it
+                    flow_url = (
+                        "https://hubeau.eaufrance.fr/api/v2/hydrometrie/observations_tr"
+                        f"?format=json&code_entite={code}"
+                        "&grandeur_hydro=Q&size=1"
+                        "&fields=code_station,date_obs,resultat_obs"
+                    )
+                    try:
+                        async with session.get(flow_url, timeout=aiohttp.ClientTimeout(total=15)) as fresp:
+                            if fresp.status in (200, 206):
+                                fdata = await fresp.json()
+                                fobs = fdata.get("data", [])
+                                if fobs:
+                                    raw_q = fobs[0].get("resultat_obs")
+                                    flow_m3s = round(float(raw_q), 3) if raw_q is not None else None
+                                    self._vigicrues_caches[code]["flow_m3s"] = flow_m3s
+                                    self._vigicrues_caches[code]["flow_obs_time"] = fobs[0].get("date_obs")
+                                    _LOGGER.debug(
+                                        "ws_core Vigicrues: %s flow=%.3f m³/s",
+                                        code,
+                                        flow_m3s or 0,
+                                    )
+                    except (aiohttp.ClientError, TimeoutError, ValueError):
+                        pass  # Flow data is optional; level data still reported
+
                     need_refresh = True
 
         except (aiohttp.ClientError, TimeoutError, ValueError) as exc:

--- a/custom_components/ws_core/sensor.py
+++ b/custom_components/ws_core/sensor.py
@@ -1794,8 +1794,10 @@ class WSRiverSensor(CoordinatorEntity, SensorEntity):
         uid_suffix = self._station_code if self._station_code else "auto"
         self._attr_unique_id = f"{entry.entry_id}_river_level_{uid_suffix}"
         name_slug = _river_slug(self._river_name or self._station_name)
-        slug = f"river_level_{name_slug}" if name_slug else (
-            f"river_level_{uid_suffix}" if uid_suffix != "auto" else "river_level"
+        slug = (
+            f"river_level_{name_slug}"
+            if name_slug
+            else (f"river_level_{uid_suffix}" if uid_suffix != "auto" else "river_level")
         )
         self._attr_suggested_object_id = f"{prefix}_{slug}"
 
@@ -1877,8 +1879,10 @@ class WSRiverFlowSensor(CoordinatorEntity, SensorEntity):
         uid_suffix = self._station_code if self._station_code else "auto"
         self._attr_unique_id = f"{entry.entry_id}_river_flow_{uid_suffix}"
         name_slug = _river_slug(self._river_name or self._station_name)
-        slug = f"river_flow_{name_slug}" if name_slug else (
-            f"river_flow_{uid_suffix}" if uid_suffix != "auto" else "river_flow"
+        slug = (
+            f"river_flow_{name_slug}"
+            if name_slug
+            else (f"river_flow_{uid_suffix}" if uid_suffix != "auto" else "river_flow")
         )
         self._attr_suggested_object_id = f"{prefix}_{slug}"
 

--- a/custom_components/ws_core/sensor.py
+++ b/custom_components/ws_core/sensor.py
@@ -1495,6 +1495,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                 stations = [{"code": "", "name": "", "river": ""}]
         for st in stations:
             entities.append(WSRiverSensor(coordinator, entry, prefix, st))
+            entities.append(WSRiverFlowSensor(coordinator, entry, prefix, st))
 
     async_add_entities(entities)
 
@@ -1751,6 +1752,15 @@ class WSSensor(RestoreEntity, CoordinatorEntity, SensorEntity):
 # ---------------------------------------------------------------------------
 
 
+_RIVER_SLUG_MAP = str.maketrans("éèêëàâäôöùûüîïç", "eeeeaaaoouuuiic")
+
+
+def _river_slug(name: str) -> str:
+    """Return a safe ASCII slug from a river or station name for use in entity IDs."""
+    slug = name.lower().translate(_RIVER_SLUG_MAP).replace(" ", "_").replace("-", "_").replace("'", "")
+    return "".join(c for c in slug if c.isalnum() or c == "_").strip("_")
+
+
 class WSRiverSensor(CoordinatorEntity, SensorEntity):
     """Real-time water level for a single Vigicrues hydrometric station.
 
@@ -1783,7 +1793,10 @@ class WSRiverSensor(CoordinatorEntity, SensorEntity):
         # Unique ID uses station code; fall back to "auto" for auto-detect mode
         uid_suffix = self._station_code if self._station_code else "auto"
         self._attr_unique_id = f"{entry.entry_id}_river_level_{uid_suffix}"
-        slug = f"river_level_{uid_suffix}" if uid_suffix != "auto" else "river_level"
+        name_slug = _river_slug(self._river_name or self._station_name)
+        slug = f"river_level_{name_slug}" if name_slug else (
+            f"river_level_{uid_suffix}" if uid_suffix != "auto" else "river_level"
+        )
         self._attr_suggested_object_id = f"{prefix}_{slug}"
 
     @property
@@ -1827,6 +1840,78 @@ class WSRiverSensor(CoordinatorEntity, SensorEntity):
             "river": d.get(f"_river_name_{code}") or self._river_name,
             "station_code": d.get(f"_river_station_code_{code}") or code,
             "observed_at": d.get(f"_river_obs_time_{code}"),
+        }
+
+    @property
+    def device_info(self) -> dict:
+        return {"identifiers": {(DOMAIN, self._entry.entry_id)}}
+
+
+class WSRiverFlowSensor(CoordinatorEntity, SensorEntity):
+    """Real-time river flow (discharge) for a single Vigicrues hydrometric station.
+
+    Flow data (grandeur_hydro=Q) is optional — not all stations provide it.
+    The sensor is always created but returns None when the API has no Q data.
+    """
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:water-flow"
+    _attr_native_unit_of_measurement = "m³/s"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_device_class = None
+
+    def __init__(
+        self,
+        coordinator,
+        entry: ConfigEntry,
+        prefix: str,
+        station: dict,
+    ) -> None:
+        super().__init__(coordinator)
+        self._entry = entry
+        self._prefix = prefix
+        self._station_code: str = (station.get("code") or "").strip()
+        self._station_name: str = station.get("name") or self._station_code
+        self._river_name: str = station.get("river") or ""
+
+        uid_suffix = self._station_code if self._station_code else "auto"
+        self._attr_unique_id = f"{entry.entry_id}_river_flow_{uid_suffix}"
+        name_slug = _river_slug(self._river_name or self._station_name)
+        slug = f"river_flow_{name_slug}" if name_slug else (
+            f"river_flow_{uid_suffix}" if uid_suffix != "auto" else "river_flow"
+        )
+        self._attr_suggested_object_id = f"{prefix}_{slug}"
+
+    @property
+    def _resolved_code(self) -> str:
+        if self._station_code:
+            return self._station_code
+        return (self.coordinator.data or {}).get("_vigicrues_auto_code", "")
+
+    @property
+    def name(self) -> str:
+        d = self.coordinator.data or {}
+        code = self._resolved_code
+        river = d.get(f"_river_name_{code}") or self._river_name
+        if river:
+            return f"WS River Flow — {river}"
+        station = d.get(f"_river_station_name_{code}") or self._station_name
+        return f"WS River Flow — {station}" if station else "WS River Flow"
+
+    @property
+    def native_value(self):
+        d = self.coordinator.data or {}
+        return d.get(f"river_flow_m3s_{self._resolved_code}")
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        d = self.coordinator.data or {}
+        code = self._resolved_code
+        return {
+            "station": d.get(f"_river_station_name_{code}") or self._station_name,
+            "river": d.get(f"_river_name_{code}") or self._river_name,
+            "station_code": d.get(f"_river_station_code_{code}") or code,
+            "observed_at": d.get(f"_river_flow_obs_time_{code}"),
         }
 
     @property

--- a/custom_components/ws_core/strings.json
+++ b/custom_components/ws_core/strings.json
@@ -71,7 +71,7 @@
       },
       "forecast_api_key": {
         "title": "Forecast Provider API Key",
-        "description": "Enter the API key for {provider_name}. You can get a free key from the provider's website.",
+        "description": "Enter the API key for {provider_name}. [Get your free API key]({api_url}).",
         "data": {
           "forecast_api_key": "API Key",
           "_go_back": "← Go back to previous step"
@@ -261,7 +261,7 @@
       },
       "forecast_api_key_opt": {
         "title": "Forecast Provider API Key",
-        "description": "Enter the API key for {provider_name}.",
+        "description": "Enter the API key for {provider_name}. [Get your free API key]({api_url}).",
         "data": {
           "forecast_api_key": "API Key"
         },

--- a/custom_components/ws_core/translations/en.json
+++ b/custom_components/ws_core/translations/en.json
@@ -71,7 +71,7 @@
       },
       "forecast_api_key": {
         "title": "Forecast Provider API Key",
-        "description": "Enter the API key for {provider_name}. You can get a free key from the provider's website.",
+        "description": "Enter the API key for {provider_name}. [Get your free API key]({api_url}).",
         "data": {
           "forecast_api_key": "API Key",
           "_go_back": "← Go back to previous step"
@@ -261,7 +261,7 @@
       },
       "forecast_api_key_opt": {
         "title": "Forecast Provider API Key",
-        "description": "Enter the API key for {provider_name}.",
+        "description": "Enter the API key for {provider_name}. [Get your free API key]({api_url}).",
         "data": {
           "forecast_api_key": "API Key"
         },

--- a/custom_components/ws_core/translations/fr.json
+++ b/custom_components/ws_core/translations/fr.json
@@ -71,7 +71,7 @@
       },
       "forecast_api_key": {
         "title": "Clé API du fournisseur de prévisions météo",
-        "description": "Entrez la clé API pour {provider_name}. Vous pouvez obtenir une clé gratuite sur le site du fournisseur.",
+        "description": "Entrez la clé API pour {provider_name}. [Obtenez votre clé API gratuite]({api_url}).",
         "data": {
           "forecast_api_key": "Clé API",
           "_go_back": "← Retour à l'étape précédente"
@@ -261,7 +261,7 @@
       },
       "forecast_api_key_opt": {
         "title": "Clé API du fournisseur de prévisions",
-        "description": "Entrez la clé API pour {provider_name}.",
+        "description": "Entrez la clé API pour {provider_name}. [Obtenez votre clé API gratuite]({api_url}).",
         "data": {
           "forecast_api_key": "Clé API"
         },


### PR DESCRIPTION
Closes #45, closes #46

## Issue #46 — Provider API links in config flow

The `forecast_api_key` and `forecast_api_key_opt` steps now show a direct clickable link to the provider's API registration page alongside the key prompt. No new config keys — the URL is derived at render time from the already-selected provider.

| Provider | URL |
|---|---|
| OpenWeatherMap | https://openweathermap.org/api |
| Pirate Weather | https://pirateweather.net/en/latest/ |
| Météo France | https://portail-api.meteofrance.fr/ |

Strings updated in `strings.json`, `translations/en.json`, and `translations/fr.json`.

## Issue #45 — Vigicrues improvements

### Better entity IDs

The default entity_id for river sensors now uses the river/station name instead of the raw station code:
- Before: `sensor.ws_river_level_V1234567`
- After: `sensor.ws_river_level_loire`

Implemented via a new `_river_slug()` helper (handles French accents: é→e, à→a, ç→c, etc.) used in `_attr_suggested_object_id`. The `unique_id` is unchanged so existing registered entities are unaffected.

### River flow (discharge) sensor

Each Vigicrues station now also spawns a `WSRiverFlowSensor` (m³/s) that fetches `grandeur_hydro=Q` from Hub'Eau v2 alongside the existing height (`H`) call. Changes:

- **coordinator.py**: Q fetch wrapped in its own `try/except` so a station without discharge data still reports its level normally. Caches `flow_m3s` and `flow_obs_time` per station.
- **sensor.py**: new `WSRiverFlowSensor` class; created for every station alongside `WSRiverSensor`.

## Test plan

- [ ] Configure integration with OpenWeatherMap — verify the API key step shows a clickable link to openweathermap.org/api
- [ ] Same for Pirate Weather and Météo France
- [ ] Verify the options-flow API key step also shows the link
- [ ] Add a Vigicrues station (France) — verify a `river_level` and `river_flow` sensor both appear
- [ ] Station entity IDs use river name (e.g. `sensor.ws_river_level_loire`) for new setups
- [ ] On a station without Q data, the flow sensor shows `unavailable` / `None`; level sensor is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)