### PR TITLE
Update coordinator

### DIFF
--- a/custom_components/ws_core/coordinator.py
+++ b/custom_components/ws_core/coordinator.py
@@ -1099,7 +1099,7 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._unsubs.append(
                 async_track_time_interval(
                     self.hass,
-                    lambda _now: self.hass.async_create_task(self._async_fetch_vigicrues()),
+                    lambda _now: self.hass.add_job(self._async_fetch_vigicrues),
                     timedelta(minutes=15),
                 )
             )


### PR DESCRIPTION
Enregistreur: homeassistant

Source: helpers/frame.py:364

S'est produit pour la première fois: 7 juin 2026 à 10:42:51 (293 occurrences)

Dernier enregistrement: 10:57:51



Error doing job: Future exception was never retrieved (task: None)

Traceback (most recent call last):

  File "/usr/local/lib/python3.14/concurrent/futures/thread.py", line 86, in run

    result = ctx.run(self.task)

  File "/usr/local/lib/python3.14/concurrent/futures/thread.py", line 73, in run

    return fn(*args, **kwargs)

  File "/config/custom_components/ws_core/coordinator.py", line 758, in <lambda>

    lambda _now: self.hass.async_create_task(self._async_fetch_vigicrues()),

                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/src/homeassistant/homeassistant/core.py", line 780, in async_create_task

    frame.report_non_thread_safe_operation("hass.async_create_task")

    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/src/homeassistant/homeassistant/helpers/frame.py", line 415, in report_non_thread_safe_operation

    report_usage(

    ~~~~~~~~~~~~^

        f"calls {what} from a thread other than the event loop, "

        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    ...<6 lines>...

        custom_integration_behavior=ReportBehavior.ERROR,

        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    )

    ^

  File "/usr/src/homeassistant/homeassistant/helpers/frame.py", line 216, in report_usage

    future.result()

    ~~~~~~~~~~~~~^^

  File "/usr/local/lib/python3.14/concurrent/futures/_base.py", line 450, in result

    return self.__get_result()

           ~~~~~~~~~~~~~~~~~^^

  File "/usr/local/lib/python3.14/concurrent/futures/_base.py", line 395, in __get_result

    raise self._exception

  File "/usr/src/homeassistant/homeassistant/util/async_.py", line 65, in run_callback

    future.set_result(callback(*args))

                      ~~~~~~~~^^^^^^^

  File "/usr/src/homeassistant/homeassistant/helpers/frame.py", line 264, in _report_usage

    _report_usage_integration_frame(

    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^

        hass,

        ^^^^^

    ...<4 lines>...

        integration_behavior is ReportBehavior.ERROR,

        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    )

    ^

  File "/usr/src/homeassistant/homeassistant/helpers/frame.py", line 364, in _report_usage_integration_frame

    raise RuntimeError(

    ...<5 lines>...

    )

RuntimeError: Detected that custom integration 'ws_core' calls hass.async_create_task from a thread other than the event loop, which may cause Home Assistant to crash or data to corrupt. For more information, see https://developers.home-assistant.io/docs/asyncio_thread_safety/#hassasync_create_task at custom_components/ws_core/coordinator.py, line 758: lambda _now: self.hass.async_create_task(self._async_fetch_vigicrues()),. Please create a bug report at https://github.com/kmich/ha_ws_core/issues

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran -->
<!--- Include screenshots if appropriate -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project
- [ ] I have updated the documentation accordingly (if needed)
- [ ] I have added tests to cover my changes (if applicable)
- [ ] All new and existing tests passed
- [ ] I have updated CHANGELOG.md with my changes
