### PR TITLE
Fix configuration and forecast diagnostics issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,11 +447,14 @@ for use as automation triggers. Requires Home Assistant 2023.8+.
 | `weather.ws` | weather | Standard HA weather entity with daily forecast |
 | `binary_sensor.ws_package_ok` | binary_sensor | True when all required sources are mapped and available |
 | `select.ws_graph_range` | select | Dashboard graph time range (6h/24h/3d) |
-| `switch.ws_enable_animations` | switch | Dashboard animation toggle |
+| `sensor.ws_forecast_provider` | sensor | Active forecast provider diagnostic |
+| `switch.ws_enable_animations` | switch | Dashboard-only animation toggle; does not enable or disable weather calculations |
 
 ### Configuration Entities (device page)
 
 All configurable parameters are exposed as entities on the device page so you can adjust them directly without entering the config flow. Changes trigger a coordinator reload automatically.
+
+Use **Configure** from the integration entry to remap required and optional source sensors after setup. This lets you replace weather-station hardware or clear optional sources without deleting and recreating the integration.
 
 **Number entities** (thresholds, calibration offsets, algorithm parameters):
 
@@ -472,7 +475,7 @@ All configurable parameters are exposed as entities on the device page so you ca
 
 | Entity | Description |
 |---|---|
-| `switch.ws_enable_display_sensors` | Display sensors (levels, trends, health) |
+| `switch.ws_enable_display_sensors` | Display-oriented helper sensors: humidity/UV levels, temperature/rain displays, pressure trend, station health, and forecast tiles |
 | `switch.ws_enable_fire_risk_score` | Fire risk score |
 | `switch.ws_enable_fog` | Fog probability |
 | `switch.ws_enable_thunderstorm_risk` | Thunderstorm risk index |
@@ -1067,7 +1070,7 @@ Offsets are applied after unit conversion, before all derived calculations (dew 
 
 ## Forecast Provider
 
-`sensor.ws_forecast_daily` and all NWP-derived sensors use a swappable forecast backend. Change it at any time via **Configure** (Settings → Devices & Services → Weather Station Core → Configure) - no reinstall needed.
+`sensor.ws_forecast_daily` and all NWP-derived sensors use a swappable forecast backend. Change it at any time via **Configure** (Settings → Devices & Services → Weather Station Core → Configure) - no reinstall needed. `sensor.ws_forecast_provider` shows the active provider and stays available even before a successful forecast fetch.
 
 | Provider | Free | API key | Notes |
 |---|---|---|---|

--- a/custom_components/ws_core/config_flow.py
+++ b/custom_components/ws_core/config_flow.py
@@ -1753,15 +1753,80 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
             out[CONF_RAIN_PENALTY_HEAVY_MMPH] = _convert_rain_to_mmph(
                 float(out.get(CONF_RAIN_PENALTY_HEAVY_MMPH, DEFAULT_RAIN_PENALTY_HEAVY_MMPH)), imperial
             )
-            # Merge into options - features step comes next (API key step if needed)
+            # Merge into options - source mapping step comes next.
             self._opt: dict[str, Any] = out
-            if out.get(CONF_FORECAST_PROVIDER) in PROVIDERS_REQUIRING_API_KEY:
-                return await self.async_step_forecast_api_key_opt()
-            return await self.async_step_features_opt()
+            return await self.async_step_required_sources_opt()
 
         return self.async_show_form(
             step_id="init",
             data_schema=self._build_core_schema(imperial, gust_u, rain_u, temp_u),
+            last_step=False,
+        )
+
+    def _current_sources_for_options(self) -> dict[str, str]:
+        defaults = _guess_defaults(self.hass)
+        current = dict(self.config_entry.data.get(CONF_SOURCES, {}))
+        current.update(self.config_entry.options.get(CONF_SOURCES, {}) or {})
+        return {**defaults, **{k: v for k, v in current.items() if v}}
+
+    async def async_step_required_sources_opt(self, user_input: dict[str, Any] | None = None):
+        defaults = self._current_sources_for_options()
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            sources = dict(self._get(CONF_SOURCES, {}))
+            for k in REQUIRED_SOURCES:
+                eid = user_input.get(k)
+                if not eid:
+                    errors[k] = "required"
+                else:
+                    err = self._validate_numeric_sensor(eid)
+                    if err:
+                        errors[k] = err
+                    else:
+                        sources[k] = eid
+            if not errors:
+                self._opt[CONF_SOURCES] = sources
+                return await self.async_step_optional_sources_opt()
+
+        fields = {vol.Required(k, default=defaults.get(k)): _ENTITY_SELECTOR for k in REQUIRED_SOURCES}
+        return self.async_show_form(
+            step_id="required_sources_opt",
+            data_schema=vol.Schema(fields),
+            errors=errors,
+            last_step=False,
+        )
+
+    async def async_step_optional_sources_opt(self, user_input: dict[str, Any] | None = None):
+        defaults = self._current_sources_for_options()
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            sources = dict(self._opt.get(CONF_SOURCES) or self._get(CONF_SOURCES, {}))
+            for k in OPTIONAL_SOURCES:
+                sources.pop(k, None)
+                eid = user_input.get(k)
+                if not eid:
+                    continue
+                err = self._validate_numeric_sensor(eid)
+                if err:
+                    errors[k] = err
+                else:
+                    sources[k] = eid
+            if not errors:
+                self._opt[CONF_SOURCES] = sources
+                if self._opt.get(CONF_FORECAST_PROVIDER) in PROVIDERS_REQUIRING_API_KEY:
+                    return await self.async_step_forecast_api_key_opt()
+                return await self.async_step_features_opt()
+
+        fields = {
+            (vol.Optional(k, default=defaults[k]) if k in defaults else vol.Optional(k)): _ENTITY_SELECTOR
+            for k in OPTIONAL_SOURCES
+        }
+        return self.async_show_form(
+            step_id="optional_sources_opt",
+            data_schema=vol.Schema(fields),
+            errors=errors,
             last_step=False,
         )
 

--- a/custom_components/ws_core/const.py
+++ b/custom_components/ws_core/const.py
@@ -167,6 +167,7 @@ KEY_DATA_QUALITY = "data_quality"
 KEY_PACKAGE_STATUS = "package_status"
 KEY_PACKAGE_OK = "package_ok"
 KEY_FORECAST = "forecast"
+KEY_FORECAST_PROVIDER = "forecast_provider"
 
 # Keys for ADVANCED METEOROLOGICAL SENSORS
 KEY_FEELS_LIKE_C = "feels_like_c"

--- a/custom_components/ws_core/coordinator.py
+++ b/custom_components/ws_core/coordinator.py
@@ -323,6 +323,7 @@ from .const import (
     KEY_FOG_PROBABILITY,
     KEY_FORECAST,
     KEY_FORECAST_AGREEMENT,
+    KEY_FORECAST_PROVIDER,
     KEY_FORECAST_SKILL,
     KEY_FORECAST_TILES,
     KEY_FREEZING_LEVEL_M,
@@ -582,7 +583,7 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.entry_options = entry_options or {}
         self.runtime = WSStationRuntime()
 
-        self.sources: dict[str, str] = dict(entry_data.get(CONF_SOURCES, {}))
+        self.sources: dict[str, str] = dict((entry_options or {}).get(CONF_SOURCES) or entry_data.get(CONF_SOURCES, {}))
 
         def _get(key: str, default: Any) -> Any:
             return self.entry_options.get(key, entry_data.get(key, default))
@@ -2447,6 +2448,7 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     ir.async_delete_issue(self.hass, DOMAIN, "stale_sensors")
 
                 if self.runtime.forecast_consecutive_failures >= 3:
+                    provider = get_provider(self.forecast_provider)
                     ir.async_create_issue(
                         self.hass,
                         DOMAIN,
@@ -2454,7 +2456,10 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         is_fixable=False,
                         severity=ir.IssueSeverity.WARNING,
                         translation_key="forecast_api_failures",
-                        translation_placeholders={"failures": str(self.runtime.forecast_consecutive_failures)},
+                        translation_placeholders={
+                            "failures": str(self.runtime.forecast_consecutive_failures),
+                            "provider": provider.PROVIDER_NAME,
+                        },
                     )
                 else:
                     ir.async_delete_issue(self.hass, DOMAIN, "forecast_api_failures")
@@ -3174,6 +3179,11 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Periodic save of learning state (async, fire-and-forget)
         with contextlib.suppress(RuntimeError):
             self.hass.async_create_task(self._async_maybe_save_learning())
+
+        provider = get_provider(self.forecast_provider)
+        data[KEY_FORECAST_PROVIDER] = self.forecast_provider
+        data["_forecast_provider_name"] = provider.PROVIDER_NAME
+        data["_forecast_provider_enabled"] = self.forecast_enabled
 
         if self.forecast_enabled:
             data[KEY_FORECAST] = self._get_cached_or_schedule_forecast(now)

--- a/custom_components/ws_core/sensor.py
+++ b/custom_components/ws_core/sensor.py
@@ -52,6 +52,7 @@ from .const import (
     CONF_ENABLE_WEATHERCLOUD,
     CONF_ENABLE_WINDY,
     CONF_ENABLE_WOW,
+    CONF_ENABLE_WUNDERGROUND,
     CONF_PREFIX,
     CONF_VIGICRUES_RIVER_NAME,
     CONF_VIGICRUES_STATION_CODE,
@@ -98,6 +99,7 @@ from .const import (
     KEY_FOG_PROBABILITY,
     KEY_FORECAST,
     KEY_FORECAST_AGREEMENT,
+    KEY_FORECAST_PROVIDER,
     KEY_FORECAST_SKILL,
     KEY_FORECAST_TILES,
     KEY_FREEZING_LEVEL_M,
@@ -494,6 +496,17 @@ SENSORS: list[WSSensorDescription] = [
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda d: (d.get(KEY_FORECAST) or {}).get("provider") if d.get(KEY_FORECAST) else None,
         attrs_fn=lambda d: d.get(KEY_FORECAST) or {},
+    ),
+    WSSensorDescription(
+        key=KEY_FORECAST_PROVIDER,
+        translation_key="forecast_provider",
+        name="WS Forecast Provider",
+        icon="mdi:cloud-search",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        attrs_fn=lambda d: {
+            "provider_name": d.get("_forecast_provider_name"),
+            "forecast_enabled": d.get("_forecast_provider_enabled"),
+        },
     ),
     # =========================================================================
     # ADVANCED METEOROLOGICAL SENSORS
@@ -2099,6 +2112,7 @@ _FEATURE_TOGGLE_MAP: dict[str, str] = {
     KEY_LIGHTNING_CLEARANCE_MIN: CONF_ENABLE_LIGHTNING,
     KEY_LIGHTNING_PROXIMITY: CONF_ENABLE_LIGHTNING,
     # v2.0 - upload status sensors
+    KEY_WU_STATUS: CONF_ENABLE_WUNDERGROUND,
     KEY_WC_STATUS: CONF_ENABLE_WEATHERCLOUD,
     KEY_PWS_STATUS: CONF_ENABLE_PWSWEATHER,
     KEY_WOW_STATUS: CONF_ENABLE_WOW,

--- a/custom_components/ws_core/strings.json
+++ b/custom_components/ws_core/strings.json
@@ -366,6 +366,35 @@
           "forecast_api_key": "Paste your API key here."
         }
       },
+      "required_sources_opt": {
+        "title": "Required source sensors",
+        "description": "Update the source entities used by Weather Station Core. These mappings can be changed when hardware is replaced.",
+        "data": {
+          "temperature": "Temperature sensor",
+          "humidity": "Humidity sensor",
+          "pressure": "Pressure sensor",
+          "wind_speed": "Wind speed sensor",
+          "wind_gust": "Wind gust sensor",
+          "wind_direction": "Wind direction sensor (degrees)",
+          "rain_total": "Cumulative precipitation sensor"
+        }
+      },
+      "optional_sources_opt": {
+        "title": "Optional source sensors",
+        "description": "Update optional source entities. Clear a field to stop using that optional source.",
+        "data": {
+          "illuminance": "Illuminance / solar radiation (lux)",
+          "uv_index": "UV index",
+          "dew_point": "Dew point (if your station provides it; otherwise it is calculated)",
+          "battery": "Station battery level (%)",
+          "solar_radiation": "Solar radiation (W/m², for Penman-Monteith ET₀)",
+          "lightning_count": "Lightning strike count (cumulative, e.g. from WH57 or AS3935)",
+          "lightning_dist": "Lightning nearest distance (km, e.g. from WH57)",
+          "indoor_temp": "Indoor temperature sensor",
+          "indoor_humidity": "Indoor humidity sensor",
+          "indoor_co2": "Indoor CO₂ sensor (ppm)"
+        }
+      },
       "features_opt": {
         "title": "Features",
         "description": "Toggle sensors and enable external data sources. Sub-steps will appear for each enabled feature.",
@@ -556,8 +585,8 @@
       "description": "The following sensors have not updated within the staleness timeout: {sensors}. Check that your weather station hardware is online and connected."
     },
     "forecast_api_failures": {
-      "title": "Open-Meteo forecast API failures",
-      "description": "The Open-Meteo forecast API has failed {failures} consecutive times. Forecast data may be stale. Check your internet connection. The integration will retry automatically with exponential backoff."
+      "title": "Forecast provider API failures",
+      "description": "The active forecast provider ({provider}) has failed {failures} consecutive times. Forecast data may be stale. Check your internet connection and provider settings. The integration will retry automatically with exponential backoff."
     }
   },
   "entity": {
@@ -692,6 +721,17 @@
       },
       "forecast_daily": {
         "name": "Forecast Daily"
+      },
+      "forecast_provider": {
+        "name": "Forecast Provider",
+        "state_attributes": {
+          "provider_name": {
+            "name": "Provider name"
+          },
+          "forecast_enabled": {
+            "name": "Forecast enabled"
+          }
+        }
       },
       "feels_like": {
         "name": "Feels Like",

--- a/custom_components/ws_core/switch.py
+++ b/custom_components/ws_core/switch.py
@@ -101,6 +101,7 @@ class WSFeatureDesc:
     name: str
     icon: str
     inverted: bool = False
+    description: str | None = None
 
 
 FEATURE_SWITCHES: tuple[WSFeatureDesc, ...] = (
@@ -109,6 +110,7 @@ FEATURE_SWITCHES: tuple[WSFeatureDesc, ...] = (
         default=DEFAULT_ENABLE_DISPLAY_SENSORS,
         name="Feature: Display Sensors",
         icon="mdi:monitor-dashboard",
+        description="Shows display-oriented helper sensors such as humidity level, UV level, pressure trend, station health, and forecast tiles.",
     ),
     # v0.3.0: removed laundry/stargazing/running score switches (cut sensors)
     WSFeatureDesc(
@@ -367,6 +369,13 @@ class WSToggleSwitch(RestoreEntity, SwitchEntity):
         if last_state:
             self._attr_is_on = last_state.state == "on"
 
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        return {
+            "description": "Controls dashboard-only animation behavior; it does not enable or disable weather calculations.",
+            "scope": "dashboard",
+        }
+
     async def async_turn_on(self, **kwargs) -> None:
         self._attr_is_on = True
         self.async_write_ha_state()
@@ -428,6 +437,13 @@ class WSFeatureSwitch(SwitchEntity):
             )
         )
         return (not stored) if self._desc.inverted else stored
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        attrs: dict[str, Any] = {"config_key": self._desc.conf_key}
+        if self._desc.description:
+            attrs["description"] = self._desc.description
+        return attrs
 
     async def async_turn_on(self, **kwargs) -> None:
         """Enable the feature."""

--- a/custom_components/ws_core/translations/en.json
+++ b/custom_components/ws_core/translations/en.json
@@ -366,6 +366,35 @@
           "forecast_api_key": "Paste your API key here."
         }
       },
+      "required_sources_opt": {
+        "title": "Required source sensors",
+        "description": "Update the source entities used by Weather Station Core. These mappings can be changed when hardware is replaced.",
+        "data": {
+          "temperature": "Temperature sensor",
+          "humidity": "Humidity sensor",
+          "pressure": "Pressure sensor",
+          "wind_speed": "Wind speed sensor",
+          "wind_gust": "Wind gust sensor",
+          "wind_direction": "Wind direction sensor (degrees)",
+          "rain_total": "Cumulative precipitation sensor"
+        }
+      },
+      "optional_sources_opt": {
+        "title": "Optional source sensors",
+        "description": "Update optional source entities. Clear a field to stop using that optional source.",
+        "data": {
+          "illuminance": "Illuminance / solar radiation (lux)",
+          "uv_index": "UV index",
+          "dew_point": "Dew point (if your station provides it; otherwise it is calculated)",
+          "battery": "Station battery level (%)",
+          "solar_radiation": "Solar radiation (W/m², for Penman-Monteith ET₀)",
+          "lightning_count": "Lightning strike count (cumulative, e.g. from WH57 or AS3935)",
+          "lightning_dist": "Lightning nearest distance (km, e.g. from WH57)",
+          "indoor_temp": "Indoor temperature sensor",
+          "indoor_humidity": "Indoor humidity sensor",
+          "indoor_co2": "Indoor CO₂ sensor (ppm)"
+        }
+      },
       "features_opt": {
         "title": "Features",
         "description": "Toggle sensors and enable external data sources. Sub-steps will appear for each enabled feature.",
@@ -556,8 +585,8 @@
       "description": "The following sensors have not updated within the staleness timeout: {sensors}. Check that your weather station hardware is online and connected."
     },
     "forecast_api_failures": {
-      "title": "Open-Meteo forecast API failures",
-      "description": "The Open-Meteo forecast API has failed {failures} consecutive times. Forecast data may be stale. Check your internet connection. The integration will retry automatically with exponential backoff."
+      "title": "Forecast provider API failures",
+      "description": "The active forecast provider ({provider}) has failed {failures} consecutive times. Forecast data may be stale. Check your internet connection and provider settings. The integration will retry automatically with exponential backoff."
     }
   },
   "entity": {
@@ -692,6 +721,17 @@
       },
       "forecast_daily": {
         "name": "Forecast Daily"
+      },
+      "forecast_provider": {
+        "name": "Forecast Provider",
+        "state_attributes": {
+          "provider_name": {
+            "name": "Provider name"
+          },
+          "forecast_enabled": {
+            "name": "Forecast enabled"
+          }
+        }
       },
       "feels_like": {
         "name": "Feels Like",


### PR DESCRIPTION
## Summary
- add a dedicated forecast provider diagnostic sensor and provider-aware forecast failure Repairs text
- allow required and optional source sensors to be remapped from Configure without reinstalling
- gate Weather Underground upload status sensor behind the WU feature toggle
- clarify the dashboard animation and display sensor switches in entity attributes and README

## Issues
Fixes #55
Fixes #57
Fixes #61
Fixes #64
Fixes #65

## Validation
- `python -m py_compile custom_components/ws_core/const.py custom_components/ws_core/coordinator.py custom_components/ws_core/sensor.py custom_components/ws_core/config_flow.py custom_components/ws_core/switch.py`
- `python -m json.tool custom_components/ws_core/translations/en.json`
- `python -m json.tool custom_components/ws_core/strings.json`
- `ruff check custom_components/ws_core/const.py custom_components/ws_core/coordinator.py custom_components/ws_core/sensor.py custom_components/ws_core/config_flow.py custom_components/ws_core/switch.py`
- `git diff --check`

Note: local `pytest` on Windows is blocked during setup by `pytest_socket.SocketBlockedError` while creating the Home Assistant/asyncio event loop self-pipe, before assertions run. CI should be the source of truth for pytest.