### PR TITLE
Prepare v2.0.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Weather Station Core are documented here.
 
+## [2.0.4] - 2026-06-10
+
+### Added
+
+- Dedicated `sensor.ws_forecast_provider` diagnostic entity showing the active forecast provider.
+- Configure-flow source remapping for required and optional weather station source sensors.
+
+### Fixed
+
+- Forecast failure Repairs text now names the active forecast provider instead of always saying Open-Meteo.
+- `sensor.ws_wu_upload_status` is only created when Weather Underground upload is enabled.
+- Clarified the purpose of `switch.ws_enable_animations` and `switch.ws_enable_display_sensors` in entity attributes and documentation.
+
 ## [2.0.2] - 2026-06-09
 
 ### Fixed

--- a/custom_components/ws_core/diagnostics.py
+++ b/custom_components/ws_core/diagnostics.py
@@ -56,7 +56,7 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigE
 
     return {
         "title": entry.title,
-        "version": "2.0.3",
+        "version": "2.0.4",
         "entry_data": _redact_coords(dict(entry.data)),
         "entry_options": _redact_coords(dict(entry.options)),
         "sources": sources,

--- a/custom_components/ws_core/manifest.json
+++ b/custom_components/ws_core/manifest.json
@@ -13,5 +13,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/kmich/ha_ws_core/issues",
   "requirements": [],
-  "version": "2.0.3"
+  "version": "2.0.4"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha_ws_core"
-version = "2.0.3"
+version = "2.0.4"
 description = "Weather Station Core - Home Assistant integration for personal weather stations"
 requires-python = ">=3.12"
 
@@ -19,4 +19,3 @@ known-third-party = ["aiohttp", "homeassistant"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
-


### PR DESCRIPTION
## Summary
- bump integration metadata from 2.0.3 to 2.0.4
- add changelog notes for the issue fixes merged in #66

## Validation
- `ruff check custom_components/`
- `ruff format --check custom_components/`
- `python -m json.tool custom_components/ws_core/manifest.json`
- `python -m json.tool hacs.json`
- version consistency check for manifest, diagnostics, and pyproject
- `git diff --check`