### PR TITLE
Fix issues #56, #58, #59, #60

### DIFF
--- a/custom_components/ws_core/algorithms.py
+++ b/custom_components/ws_core/algorithms.py
@@ -43,19 +43,15 @@ MOON_ILLUMINATION = {
 
 
 def calculate_dew_point(temp_c: float, humidity: float) -> float:
-    """Magnus-formula dew point (Alduchov & Eskridge 1996).
+    """Magnus-formula dew point over liquid water (Alduchov & Eskridge 1996).
 
-    Uses temperature-dependent constants:
-      Over water (T >= 0): a=17.625, b=243.04
-      Over ice   (T <  0): a=22.587, b=273.86 (Buck 1981)
+    Uses saturation-over-water constants at all temperatures:
+      a=17.625, b=243.04
 
     Valid range: -45 C to +60 C, 1%-100% RH.
-    Max error < 0.1 C across valid range (over water).
+    Max error < 0.1 C across valid range.
     """
-    if temp_c >= 0:
-        a, b = 17.625, 243.04
-    else:
-        a, b = 22.587, 273.86
+    a, b = 17.625, 243.04
     rh_clamped = max(1.0, min(100.0, humidity))
     gamma = (a * temp_c) / (b + temp_c) + math.log(rh_clamped / 100.0)
     return round((b * gamma) / (a - gamma), 2)
@@ -65,13 +61,13 @@ def calculate_frost_point(temp_c: float, humidity: float) -> float:
     """Frost point using Magnus formula with ice constants (Buck 1981).
 
     The frost point is the temperature at which air becomes saturated
-    with respect to ice. Only physically meaningful below 0 C.
-    Above 0 C, returns the standard dew point.
+    with respect to ice. Uses ice constants at all temperatures:
+      a=22.587, b=273.86
 
-    Constants: a=22.587, b=273.86 (saturation over ice).
+    The frost point is always numerically higher (warmer) than the dew
+    point at the same conditions, because ice requires less vapour
+    pressure to saturate than liquid water does.
     """
-    if temp_c >= 0:
-        return calculate_dew_point(temp_c, humidity)
     a, b = 22.587, 273.86
     rh_clamped = max(1.0, min(100.0, humidity))
     gamma = (a * temp_c) / (b + temp_c) + math.log(rh_clamped / 100.0)

--- a/custom_components/ws_core/config_flow.py
+++ b/custom_components/ws_core/config_flow.py
@@ -1967,11 +1967,9 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
         g = self._get
         if user_input is not None:
             self._opt.update(user_input)
-            # Route through sub-steps for enabled features (v0.3.0: METAR/CWOP/Export/DegreeDays removed)
+            # Route through sub-steps for enabled data-source features
             if user_input.get(CONF_ENABLE_SEA_TEMP):
                 return await self.async_step_sea_temp_opt()
-            if user_input.get(CONF_ENABLE_WUNDERGROUND):
-                return await self.async_step_wunderground_opt()
             if user_input.get(CONF_ENABLE_AIR_QUALITY):
                 return await self.async_step_air_quality_opt()
             if user_input.get(CONF_ENABLE_POLLEN):
@@ -1980,7 +1978,7 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
                 return await self.async_step_solar_forecast_opt()
             if user_input.get(CONF_ENABLE_VIGICRUES):
                 return await self.async_step_vigicrues_station_opt()
-            return await self._next_v2_opt_step()
+            return await self.async_step_upload_services_opt()
 
         return self.async_show_form(
             step_id="features_opt",
@@ -1990,7 +1988,6 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_ENABLE_DISPLAY_SENSORS,
                         default=g(CONF_ENABLE_DISPLAY_SENSORS, DEFAULT_ENABLE_DISPLAY_SENSORS),
                     ): selector.BooleanSelector(),
-                    # v0.3.0: removed laundry/stargazing/running/degree_days/metar/cwop/export
                     vol.Optional(
                         CONF_ENABLE_FIRE_RISK,
                         default=g(CONF_ENABLE_FIRE_RISK, DEFAULT_ENABLE_FIRE_RISK),
@@ -2004,9 +2001,6 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
                     ): selector.BooleanSelector(),
                     vol.Optional(
                         CONF_ENABLE_SEA_TEMP, default=g(CONF_ENABLE_SEA_TEMP, DEFAULT_ENABLE_SEA_TEMP)
-                    ): selector.BooleanSelector(),
-                    vol.Optional(
-                        CONF_ENABLE_WUNDERGROUND, default=g(CONF_ENABLE_WUNDERGROUND, DEFAULT_ENABLE_WUNDERGROUND)
                     ): selector.BooleanSelector(),
                     vol.Optional(
                         CONF_ENABLE_AIR_QUALITY, default=g(CONF_ENABLE_AIR_QUALITY, DEFAULT_ENABLE_AIR_QUALITY)
@@ -2049,7 +2043,6 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_ENABLE_NOWCAST,
                         default=g(CONF_ENABLE_NOWCAST, DEFAULT_ENABLE_NOWCAST),
                     ): selector.BooleanSelector(),
-                    # v2.0 feature toggles
                     vol.Optional(
                         CONF_ENABLE_DEGREE_DAYS, default=g(CONF_ENABLE_DEGREE_DAYS, DEFAULT_ENABLE_DEGREE_DAYS)
                     ): selector.BooleanSelector(),
@@ -2058,6 +2051,26 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
                     ): selector.BooleanSelector(),
                     vol.Optional(
                         CONF_ENABLE_INDOOR, default=g(CONF_ENABLE_INDOOR, DEFAULT_ENABLE_INDOOR)
+                    ): selector.BooleanSelector(),
+                }
+            ),
+            last_step=False,
+        )
+
+    async def async_step_upload_services_opt(self, user_input: dict[str, Any] | None = None):
+        g = self._get
+        if user_input is not None:
+            self._opt.update(user_input)
+            if user_input.get(CONF_ENABLE_WUNDERGROUND):
+                return await self.async_step_wunderground_opt()
+            return await self._next_v2_opt_step()
+
+        return self.async_show_form(
+            step_id="upload_services_opt",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_ENABLE_WUNDERGROUND, default=g(CONF_ENABLE_WUNDERGROUND, DEFAULT_ENABLE_WUNDERGROUND)
                     ): selector.BooleanSelector(),
                     vol.Optional(
                         CONF_ENABLE_WEATHERCLOUD, default=g(CONF_ENABLE_WEATHERCLOUD, DEFAULT_ENABLE_WEATHERCLOUD)
@@ -2386,10 +2399,9 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
     # Sub-steps for each configurable feature
     # ------------------------------------------------------------------
     def _opt_next_after(self, after: str):
-        """Route to the next enabled feature sub-step or finish."""
+        """Route to the next enabled feature sub-step."""
         order = [
             (CONF_ENABLE_SEA_TEMP, "sea_temp_opt"),
-            (CONF_ENABLE_WUNDERGROUND, "wunderground_opt"),
             (CONF_ENABLE_AIR_QUALITY, "air_quality_opt"),
             (CONF_ENABLE_POLLEN, "pollen_opt"),
             (CONF_ENABLE_SOLAR_FORECAST, "solar_forecast_opt"),
@@ -2402,13 +2414,13 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
                 continue
             if past and self._opt.get(conf_key):
                 return getattr(self, f"async_step_{step_name}")()
-        return None  # signals: go to finish
+        return None  # signals: proceed to upload_services_opt
 
     async def _finish_or_next(self, after: str):
         nxt = self._opt_next_after(after)
         if nxt is not None:
             return await nxt
-        return self.async_create_entry(title="", data=self._opt)
+        return await self.async_step_upload_services_opt()
 
     async def async_step_sea_temp_opt(self, user_input: dict[str, Any] | None = None):
         g = self._get
@@ -2455,7 +2467,7 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
                 self._opt[CONF_WU_API_KEY] = api_key
                 self._opt[CONF_WU_INTERVAL_MIN] = int(user_input.get(CONF_WU_INTERVAL_MIN, DEFAULT_WU_INTERVAL_MIN))
             if not errors:
-                return await self._finish_or_next("wunderground_opt")
+                return await self._next_v2_opt_step()
         return self.async_show_form(
             step_id="wunderground_opt",
             data_schema=vol.Schema(
@@ -2575,7 +2587,7 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
                         break
             # Empty list means auto-detect nearest station
             self._opt[CONF_VIGICRUES_STATIONS] = stations
-            return self.async_create_entry(title="", data=self._opt)
+            return await self.async_step_upload_services_opt()
 
         lat = (
             self._opt.get(CONF_FORECAST_LAT)

--- a/custom_components/ws_core/coordinator.py
+++ b/custom_components/ws_core/coordinator.py
@@ -1383,15 +1383,15 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             data[KEY_NORM_TEMP_C] = tc
 
         h_raw = num(SRC_HUM)
-        rh = round(h_raw, 1) if h_raw is not None else None
+        rh = round(h_raw, 2) if h_raw is not None else None
         if rh is not None:
-            rh = round(max(0.0, min(100.0, rh + float(self.entry_options.get("cal_humidity", 0.0)))), 1)
+            rh = round(max(0.0, min(100.0, rh + float(self.entry_options.get("cal_humidity", 0.0)))), 2)
             data[KEY_NORM_HUMIDITY] = rh
 
         p_raw = num(SRC_PRESS)
-        pressure_hpa = round(self._to_hpa(p_raw, uom(SRC_PRESS)), 1) if p_raw is not None else None
+        pressure_hpa = round(self._to_hpa(p_raw, uom(SRC_PRESS)), 2) if p_raw is not None else None
         if pressure_hpa is not None:
-            pressure_hpa = round(pressure_hpa + float(self.entry_options.get("cal_pressure_hpa", 0.0)), 1)
+            pressure_hpa = round(pressure_hpa + float(self.entry_options.get("cal_pressure_hpa", 0.0)), 2)
             data[KEY_NORM_PRESSURE_HPA] = pressure_hpa
 
         ws_raw = num(SRC_WIND)
@@ -1406,7 +1406,7 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             data[KEY_NORM_WIND_GUST_MS] = gust_ms
 
         wd_raw = num(SRC_WIND_DIR)
-        wind_dir = round(float(wd_raw), 1) if wd_raw is not None else None
+        wind_dir = round(float(wd_raw), 2) if wd_raw is not None else None
         if wind_dir is not None:
             data[KEY_NORM_WIND_DIR_DEG] = wind_dir
 
@@ -1416,7 +1416,7 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             data[KEY_NORM_RAIN_TOTAL_MM] = rain_total_mm
 
         lux_raw = num(SRC_LUX)
-        lux = round(lux_raw, 1) if lux_raw is not None else None
+        lux = round(lux_raw, 2) if lux_raw is not None else None
         if lux is not None:
             data[KEY_LUX] = lux
 
@@ -2077,13 +2077,13 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             data[KEY_INDOOR_TEMP_C] = indoor_tc
             outdoor_tc = data.get(KEY_NORM_TEMP_C)
             if outdoor_tc is not None:
-                data[KEY_INDOOR_TEMP_DELTA] = round(float(indoor_tc) - float(outdoor_tc), 1)
+                data[KEY_INDOOR_TEMP_DELTA] = round(float(indoor_tc) - float(outdoor_tc), 2)
 
         if indoor_hum_raw is not None:
-            data[KEY_INDOOR_HUMIDITY] = round(float(indoor_hum_raw), 1)
+            data[KEY_INDOOR_HUMIDITY] = round(float(indoor_hum_raw), 2)
             outdoor_rh = data.get(KEY_NORM_HUMIDITY)
             if outdoor_rh is not None:
-                data[KEY_INDOOR_HUMIDITY_DELTA] = round(float(indoor_hum_raw) - float(outdoor_rh), 1)
+                data[KEY_INDOOR_HUMIDITY_DELTA] = round(float(indoor_hum_raw) - float(outdoor_rh), 2)
 
         if indoor_co2_raw is not None:
             data[KEY_INDOOR_CO2_PPM] = round(float(indoor_co2_raw))

--- a/custom_components/ws_core/sensor.py
+++ b/custom_components/ws_core/sensor.py
@@ -1228,7 +1228,7 @@ SENSORS: list[WSSensorDescription] = [
         translation_key="forecast_tiles",
         name="WS Forecast Tiles",
         icon="mdi:calendar-weather",
-        value_fn=lambda d: "available" if d.get(KEY_FORECAST_TILES) else "unavailable",
+        value_fn=lambda d: len(d.get(KEY_FORECAST_TILES) or []),
         attrs_fn=lambda d: {
             "tiles": d.get(KEY_FORECAST_TILES) or [],
             "count": len(d.get(KEY_FORECAST_TILES) or []),

--- a/custom_components/ws_core/strings.json
+++ b/custom_components/ws_core/strings.json
@@ -397,12 +397,11 @@
       },
       "features_opt": {
         "title": "Features",
-        "description": "Toggle sensors and enable external data sources. Sub-steps will appear for each enabled feature.",
+        "description": "Toggle computed sensors and enable data-source features. Upload service settings are on the next page.",
         "data": {
           "enable_display_sensors": "Display sensors (levels, trends, health)",
           "enable_fire_risk_score": "Fire risk score",
           "enable_sea_temp": "Sea surface temperature",
-          "enable_wunderground": "Weather Underground upload",
           "enable_air_quality": "Air quality index (Open-Meteo)",
           "enable_pollen": "Pollen levels (Open-Meteo, free, no API key)",
           "enable_moon": "Moon phase & illumination",
@@ -418,20 +417,12 @@
           "enable_nowcast": "Precipitation nowcast (minutes to rain)",
           "enable_degree_days": "Degree days (HDD, CDD, GDD) and leaf wetness",
           "enable_lightning": "Lightning detection sensors",
-          "enable_indoor": "Indoor sensors (temperature, humidity, CO₂)",
-          "enable_weathercloud": "Weathercloud upload",
-          "enable_pwsweather": "PWSWeather upload",
-          "enable_wow": "WOW (UK Met Office) upload",
-          "enable_awekas": "AWEKAS upload",
-          "enable_owm_stations": "OpenWeatherMap Stations upload",
-          "enable_windy": "Windy.com upload",
-          "enable_mqtt": "MQTT Discovery republishing"
+          "enable_indoor": "Indoor sensors (temperature, humidity, CO₂)"
         },
         "data_description": {
           "enable_display_sensors": "Display sensors (levels, trends, health)",
           "enable_fire_risk_score": "Fire risk score",
           "enable_sea_temp": "Sea surface temperature",
-          "enable_wunderground": "Weather Underground upload",
           "enable_air_quality": "Air quality index (Open-Meteo)",
           "enable_pollen": "Pollen levels (Open-Meteo)",
           "enable_moon": "Moon phase & illumination",
@@ -445,6 +436,21 @@
           "enable_fwi_components": "FWI intermediate codes (FFMC/DMC/DC/ISI/BUI). Requires Fire Risk enabled to produce data",
           "enable_advanced_sensors": "Zambretti number (numeric form), hourly ET₀, smoothed wind direction",
           "enable_nowcast": "Open-Meteo 15-minute precipitation nowcast: minutes until rain starts/stops, next-hour total, intensity. No API key"
+        }
+      },
+      "upload_services_opt": {
+        "title": "Upload Services",
+        "description": "Enable sharing your weather data with external services. Sub-steps will appear for each enabled service.",
+        "data": {
+          "enable_wunderground": "Weather Underground upload",
+          "enable_weathercloud": "Weathercloud upload",
+          "enable_pwsweather": "PWSWeather upload",
+          "enable_wow": "WOW (UK Met Office) upload",
+          "enable_awekas": "AWEKAS upload",
+          "enable_owm_stations": "OpenWeatherMap Stations upload",
+          "enable_windy": "Windy.com upload",
+          "enable_cwop": "CWOP / APRS upload",
+          "enable_mqtt": "MQTT Discovery republishing"
         }
       },
       "sea_temp_opt": {


### PR DESCRIPTION
## Summary

- **#59** — Dew point and frost point returned identical values: both were using ice constants below 0°C. Dew point now always uses Magnus water constants; frost point always uses ice constants. They will always differ.
- **#60** — Sensor precision: humidity, pressure, wind direction, illuminance, indoor humidity, and delta sensors now round to 2 decimal places instead of 1.
- **#58** — `forecast_tiles` icon was hidden: `value_fn` was returning the reserved HA string `"unavailable"` when no data was present, causing HA to suppress the entity icon. Now returns the tile count (integer) instead.
- **#56** — Options flow UI simplified: the 28-toggle features page is split into **"Features"** (19 core weather toggles) and a new **"Upload Services"** page (9 upload/sharing toggles). Also fixes a pre-existing bug where upload credential sub-steps were skipped when any feature sub-step (vigicrues, solar forecast, etc.) was active.

## Test plan

- [ ] Verify dew point and frost point report different values at typical outdoor temperatures (e.g. 20°C, 60% RH)
- [ ] Verify frost point is always higher (warmer) than dew point
- [ ] Confirm humidity and pressure sensors now show 2 decimal places
- [ ] Confirm `sensor.ws_forecast_tiles` shows an icon and its state is a number (tile count)
- [ ] Open integration options → confirm "Features" page has 19 toggles, no upload service entries
- [ ] Confirm a new "Upload Services" page appears after "Features"
- [ ] Enable Vigicrues + Weathercloud in options → confirm Weathercloud credentials step is reached (was previously skipped)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)