### PR TITLE
fix: validate WU credentials via upload endpoint; rename field to station key

### DIFF
--- a/custom_components/ws_core/config_flow.py
+++ b/custom_components/ws_core/config_flow.py
@@ -143,20 +143,33 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def _validate_wu_credentials(station_id: str, api_key: str) -> tuple[bool, str]:
-    """Validate Weather Underground station ID + API key. Returns (valid, error_key)."""
+    """Validate Weather Underground station ID + station key using the upload endpoint.
+
+    The field stored as wu_api_key is the station key (PASSWORD) used by the PWS upload
+    endpoint, NOT the 32-character read API key used by api.weather.com.  Validating
+    against the upload endpoint avoids the read-API key requirement and also handles
+    stations that have never uploaded (which would return HTTP 204 from the read API,
+    previously misidentified as "cannot_connect").
+    """
     try:
         import aiohttp
 
-        url = (
-            f"https://api.weather.com/v2/pws/observations/current"
-            f"?stationId={station_id}&format=json&units=m&apiKey={api_key}&numericPrecision=decimal"
-        )
+        url = "https://weatherstation.wunderground.com/weatherstation/updateweatherstation.php"
+        params = {
+            "ID": station_id,
+            "PASSWORD": api_key,
+            "action": "updateraw",
+            "dateutc": "now",
+        }
         async with aiohttp.ClientSession() as session:
-            async with session.get(url, timeout=aiohttp.ClientTimeout(total=10)) as resp:
-                if resp.status == 200:
+            async with session.get(url, params=params, timeout=aiohttp.ClientTimeout(total=10)) as resp:
+                body = (await resp.text()).lower().strip()
+                if resp.status == 200 and "success" in body:
                     return True, ""
-                if resp.status == 401 or resp.status == 403:
+                # 401 = bad PASSWORD (station key); 403 = station exists but rejected
+                if resp.status in (401, 403):
                     return False, "invalid_api_key"
+                # station ID not recognised
                 if resp.status == 404:
                     return False, "station_not_found"
                 return False, "cannot_connect"

--- a/custom_components/ws_core/strings.json
+++ b/custom_components/ws_core/strings.json
@@ -108,10 +108,10 @@
       },
       "wunderground": {
         "title": "Weather Underground upload",
-        "description": "Upload observations to your Weather Underground Personal Weather Station. You need a station ID and API key from your Weather Underground account (wunderground.com/member/devices). Leave both fields blank to skip and configure later.",
+        "description": "Upload observations to your Weather Underground Personal Weather Station. You need a station ID and station key (password) from your Weather Underground account (wunderground.com/member/devices). Leave both fields blank to skip and configure later.",
         "data": {
           "wu_station_id": "Station ID (e.g. IATHEN123) — leave blank to skip",
-          "wu_api_key": "API key — leave blank to skip",
+          "wu_api_key": "Station key (password) — leave blank to skip",
           "wu_interval_min": "Upload interval",
           "_go_back": "← Go back to previous step"
         }
@@ -190,7 +190,7 @@
           "sea_temp_lon": "Sea temperature longitude",
           "enable_wunderground": "Weather Underground upload",
           "wu_station_id": "WU Station ID",
-          "wu_api_key": "WU API key",
+          "wu_api_key": "WU Station key (password)",
           "wu_interval_min": "WU upload interval"
         },
         "data_description": {
@@ -223,7 +223,7 @@
           "sea_temp_lon": "Sea temperature longitude",
           "enable_wunderground": "Weather Underground upload",
           "wu_station_id": "WU Station ID",
-          "wu_api_key": "WU API key",
+          "wu_api_key": "WU Station key (password)",
           "wu_interval_min": "WU upload interval"
         }
       },
@@ -267,7 +267,7 @@
         "description": "{info}",
         "data": {
           "wu_station_id": "Station ID",
-          "wu_api_key": "API key",
+          "wu_api_key": "Station key (password)",
           "wu_interval_min": "Upload interval"
         }
       },

--- a/custom_components/ws_core/translations/en.json
+++ b/custom_components/ws_core/translations/en.json
@@ -108,10 +108,10 @@
       },
       "wunderground": {
         "title": "Weather Underground upload",
-        "description": "Upload observations to your Weather Underground Personal Weather Station. You need a station ID and API key from your Weather Underground account (wunderground.com/member/devices). Leave both fields blank to skip and configure later.",
+        "description": "Upload observations to your Weather Underground Personal Weather Station. You need a station ID and station key (password) from your Weather Underground account (wunderground.com/member/devices). Leave both fields blank to skip and configure later.",
         "data": {
           "wu_station_id": "Station ID (e.g. IATHEN123) — leave blank to skip",
-          "wu_api_key": "API key — leave blank to skip",
+          "wu_api_key": "Station key (password) — leave blank to skip",
           "wu_interval_min": "Upload interval",
           "_go_back": "← Go back to previous step"
         }
@@ -190,7 +190,7 @@
           "sea_temp_lon": "Sea temperature longitude",
           "enable_wunderground": "Weather Underground upload",
           "wu_station_id": "WU Station ID",
-          "wu_api_key": "WU API key",
+          "wu_api_key": "WU Station key (password)",
           "wu_interval_min": "WU upload interval"
         },
         "data_description": {
@@ -223,7 +223,7 @@
           "sea_temp_lon": "Sea temperature longitude",
           "enable_wunderground": "Weather Underground upload",
           "wu_station_id": "WU Station ID",
-          "wu_api_key": "WU API key",
+          "wu_api_key": "WU Station key (password)",
           "wu_interval_min": "WU upload interval"
         }
       },
@@ -267,7 +267,7 @@
         "description": "{info}",
         "data": {
           "wu_station_id": "Station ID",
-          "wu_api_key": "API key",
+          "wu_api_key": "Station key (password)",
           "wu_interval_min": "Upload interval"
         }
       },


### PR DESCRIPTION
## Problem

The `wu_api_key` field stores the **station key** (used as `PASSWORD` in the upload URL), but the validator called the **read API** (`api.weather.com`), which requires a separate 32-character read API key.

This caused two failure modes that both prevented the credentials from ever being saved:

| Credential entered | Read API response | Validator decision |
|---|---|---|
| Station key (correct, ~8 chars) | HTTP 401 | `invalid_api_key` |
| Read API key (32 chars) + inactive station | HTTP 204 | `cannot_connect` |

Because `wu_api_key` was never written to storage, the upload scheduler guard:
```python
if self.wu_enabled and self.wu_station_id and self.wu_api_key:
```
was always `False` → **no uploads were ever sent**, even with the feature enabled.

## Fix

Switch `_validate_wu_credentials` to validate against the **upload endpoint** itself:
```
GET https://weatherstation.wunderground.com/weatherstation/updateweatherstation.php
    ?ID=<station_id>&PASSWORD=<station_key>&action=updateraw&dateutc=now
```
- Response body `success` → credentials are valid
- HTTP 401/403 → invalid station key
- HTTP 404 → station ID not found

This matches the credential actually stored (station key / PASSWORD) and works for stations that have never uploaded (no HTTP 204 ambiguity).

## UI labels

Rename the field from _"API key"_ to _"Station key (password)"_ in `strings.json` and `translations/en.json` to match the label shown on `wunderground.com/member/devices`.

## Files changed

- `custom_components/ws_core/config_flow.py` — `_validate_wu_credentials` rewritten
- `custom_components/ws_core/strings.json` — 4 label/description updates
- `custom_components/ws_core/translations/en.json` — same 4 label/description updates
