### PR TITLE
fix: options flow crashes + WU credential validation (v2.0.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Weather Station Core are documented here.
 
+## [2.0.7] - 2026-06-11
+
+### Fixed
+
+- **#70**: "Unknown error occurred" when editing source sensors via Configure — the options flow called `_validate_numeric_sensor`, which only existed on the config-flow class, raising `AttributeError`. The sensor validator is now a shared module-level helper used by both flows.
+- **#71**: "Entity is neither a valid entity ID nor a valid UUID" blocking the whole options dialog — the inline HA weather-entity field carried an empty-string default that fails the weather `EntitySelector`. It now uses a suggested value and is simply omitted when left blank.
+- **#72** (thanks @miczu71): Weather Underground credentials could never be saved (and so no uploads were ever sent) because the validator checked the read API (`api.weather.com`), which needs a separate 32-character read key. It now validates the **station key (password)** against the same PWS upload endpoint the uploader actually uses. The Weather Underground field is relabelled "Station key (password)" to match `wunderground.com/member/devices`.
+
 ## [2.0.6] - 2026-06-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Weather Station Core reads raw sensor data from your existing weather station - 
 
 ---
 
+## What's New in 2.0.7
+
+- **Configure dialog fixes** — editing source sensors no longer fails with "Unknown error occurred" (#70), and the general settings step no longer blocks with "Entity is neither a valid entity ID nor a valid UUID" when no HA weather entity is selected (#71).
+- **Weather Underground uploads fixed** (thanks @miczu71, #72) — credential validation now checks the **station key (password)** against the actual PWS upload endpoint, so valid credentials save correctly and uploads are sent. The field is relabelled "Station key (password)" to match `wunderground.com/member/devices`.
+
 ## What's New in 2.0.6
 
 - **HA weather entity forecast provider** — use any existing `weather.*` entity in Home Assistant as your forecast source. No extra API, no external calls. Select it in Configure → Forecast and pick an entity. Great for users already running Met.no, OpenWeatherMap, or any other HA weather integration.

--- a/custom_components/ws_core/config_flow.py
+++ b/custom_components/ws_core/config_flow.py
@@ -230,20 +230,39 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def _validate_wu_credentials(station_id: str, api_key: str) -> tuple[bool, str]:
-    """Validate Weather Underground station ID + API key. Returns (valid, error_key)."""
+    """Validate Weather Underground station ID + station key using the upload endpoint.
+
+    The field stored as ``wu_api_key`` is the station key (PASSWORD) used by the PWS
+    upload endpoint, NOT the 32-character read API key used by api.weather.com.
+    Validating against the upload endpoint matches the credential actually stored and
+    used by ``_async_upload_wunderground`` in the coordinator, and avoids two failure
+    modes of the old read-API check that prevented credentials from ever being saved
+    (issue from PR #72):
+
+      * a correct station key returned HTTP 401 from the read API -> "invalid_api_key"
+      * a read API key for a station that never uploaded returned HTTP 204 -> "cannot_connect"
+
+    Returns ``(valid, error_key)``.
+    """
     try:
         import aiohttp
 
-        url = (
-            f"https://api.weather.com/v2/pws/observations/current"
-            f"?stationId={station_id}&format=json&units=m&apiKey={api_key}&numericPrecision=decimal"
-        )
+        url = "https://weatherstation.wunderground.com/weatherstation/updateweatherstation.php"
+        params = {
+            "ID": station_id,
+            "PASSWORD": api_key,
+            "action": "updateraw",
+            "dateutc": "now",
+        }
         async with aiohttp.ClientSession() as session:
-            async with session.get(url, timeout=aiohttp.ClientTimeout(total=10)) as resp:
-                if resp.status == 200:
+            async with session.get(url, params=params, timeout=aiohttp.ClientTimeout(total=10)) as resp:
+                body = (await resp.text()).lower().strip()
+                if resp.status == 200 and "success" in body:
                     return True, ""
-                if resp.status == 401 or resp.status == 403:
+                # 401 = bad PASSWORD (station key); 403 = station exists but rejected
+                if resp.status in (401, 403):
                     return False, "invalid_api_key"
+                # station ID not recognised
                 if resp.status == 404:
                     return False, "station_not_found"
                 return False, "cannot_connect"
@@ -449,6 +468,31 @@ _ENTITY_SELECTOR = selector.EntitySelector(selector.EntitySelectorConfig(domain=
 
 
 # ---------------------------------------------------------------------------
+# Shared validation helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_numeric_sensor(hass: HomeAssistant, eid: str) -> str | None:
+    """Validate that a sensor entity exists and has a numeric state.
+
+    Returns an error key string on failure, or ``None`` when acceptable.
+    Device-class filtering has been removed (issue #41) - any numeric sensor
+    is accepted regardless of its declared device_class.
+
+    Shared by both the config flow and the options flow so source-sensor
+    validation behaves identically in either (issue #70).
+    """
+    st = hass.states.get(eid)
+    if st is None or st.state in ("unknown", "unavailable"):
+        return "entity_not_found"
+    try:
+        float(st.state)
+    except (ValueError, TypeError):
+        return "not_numeric"
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Config Flow
 # ---------------------------------------------------------------------------
 
@@ -504,20 +548,8 @@ class WSStationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return None
 
     def _validate_numeric_sensor(self, eid: str) -> str | None:
-        """Validate that a sensor entity exists and has a numeric state.
-
-        Returns an error key string on failure, or ``None`` when acceptable.
-        Device-class filtering has been removed (issue #41) — any numeric sensor
-        is accepted regardless of its declared device_class.
-        """
-        st = self.hass.states.get(eid)
-        if st is None or st.state in ("unknown", "unavailable"):
-            return "entity_not_found"
-        try:
-            float(st.state)
-        except (ValueError, TypeError):
-            return "not_numeric"
-        return None
+        """Validate a source sensor (delegates to the shared module-level helper)."""
+        return _validate_numeric_sensor(self.hass, eid)
 
     # ------------------------------------------------------------------
     # Step 1: Name & prefix
@@ -1813,7 +1845,7 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
                 if not eid:
                     errors[k] = "required"
                 else:
-                    err = self._validate_numeric_sensor(eid)
+                    err = _validate_numeric_sensor(self.hass, eid)
                     if err:
                         errors[k] = err
                     else:
@@ -1841,7 +1873,7 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
                 eid = user_input.get(k)
                 if not eid:
                     continue
-                err = self._validate_numeric_sensor(eid)
+                err = _validate_numeric_sensor(self.hass, eid)
                 if err:
                     errors[k] = err
                 else:
@@ -1938,9 +1970,15 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
                         translation_key="forecast_provider",
                     )
                 ),
-                vol.Optional(CONF_FORECAST_ENTITY, default=g(CONF_FORECAST_ENTITY, "")): selector.EntitySelector(
-                    selector.EntitySelectorConfig(domain="weather")
-                ),
+                # Optional weather entity used only by the HA-entity forecast provider.
+                # Must NOT carry a default of "" — an empty string fails the weather
+                # EntitySelector ("Entity is neither a valid entity ID nor a valid UUID")
+                # and blocked the whole options dialog (issue #71). Use a suggested value
+                # so it pre-fills when set but is simply omitted (no validation) when blank.
+                vol.Optional(
+                    CONF_FORECAST_ENTITY,
+                    description={"suggested_value": g(CONF_FORECAST_ENTITY, "") or None},
+                ): selector.EntitySelector(selector.EntitySelectorConfig(domain="weather")),
                 vol.Optional(
                     CONF_THRESH_WIND_GUST_MS, default=round(_convert_gust_to_display(cur_gust_ms, imperial), 1)
                 ): selector.NumberSelector(

--- a/custom_components/ws_core/diagnostics.py
+++ b/custom_components/ws_core/diagnostics.py
@@ -56,7 +56,7 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigE
 
     return {
         "title": entry.title,
-        "version": "2.0.6",
+        "version": "2.0.7",
         "entry_data": _redact_coords(dict(entry.data)),
         "entry_options": _redact_coords(dict(entry.options)),
         "sources": sources,

--- a/custom_components/ws_core/manifest.json
+++ b/custom_components/ws_core/manifest.json
@@ -13,5 +13,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/kmich/ha_ws_core/issues",
   "requirements": [],
-  "version": "2.0.6"
+  "version": "2.0.7"
 }

--- a/custom_components/ws_core/strings.json
+++ b/custom_components/ws_core/strings.json
@@ -224,10 +224,10 @@
       },
       "wunderground": {
         "title": "Weather Underground upload",
-        "description": "Upload observations to your Weather Underground Personal Weather Station. You need a station ID and API key from your Weather Underground account (wunderground.com/member/devices). Leave both fields blank to skip and configure later.",
+        "description": "Upload observations to your Weather Underground Personal Weather Station. You need a station ID and station key (password) from your Weather Underground account (wunderground.com/member/devices). Leave both fields blank to skip and configure later.",
         "data": {
           "wu_station_id": "Station ID (e.g. IATHEN123) - leave blank to skip",
-          "wu_api_key": "API key - leave blank to skip",
+          "wu_api_key": "Station key (password) - leave blank to skip",
           "wu_interval_min": "Upload interval",
           "_go_back": "← Go back to previous step"
         }
@@ -331,7 +331,7 @@
           "sea_temp_lon": "Sea temperature longitude",
           "enable_wunderground": "Weather Underground upload",
           "wu_station_id": "WU Station ID",
-          "wu_api_key": "WU API key",
+          "wu_api_key": "WU Station key (password)",
           "wu_interval_min": "WU upload interval"
         },
         "data_description": {
@@ -365,7 +365,7 @@
           "sea_temp_lon": "Sea temperature longitude",
           "enable_wunderground": "Weather Underground upload",
           "wu_station_id": "WU Station ID",
-          "wu_api_key": "WU API key",
+          "wu_api_key": "WU Station key (password)",
           "wu_interval_min": "WU upload interval"
         }
       },
@@ -488,7 +488,7 @@
         "description": "{info}",
         "data": {
           "wu_station_id": "Station ID",
-          "wu_api_key": "API key",
+          "wu_api_key": "Station key (password)",
           "wu_interval_min": "Upload interval"
         }
       },

--- a/custom_components/ws_core/translations/en.json
+++ b/custom_components/ws_core/translations/en.json
@@ -224,10 +224,10 @@
       },
       "wunderground": {
         "title": "Weather Underground upload",
-        "description": "Upload observations to your Weather Underground Personal Weather Station. You need a station ID and API key from your Weather Underground account (wunderground.com/member/devices). Leave both fields blank to skip and configure later.",
+        "description": "Upload observations to your Weather Underground Personal Weather Station. You need a station ID and station key (password) from your Weather Underground account (wunderground.com/member/devices). Leave both fields blank to skip and configure later.",
         "data": {
           "wu_station_id": "Station ID (e.g. IATHEN123) - leave blank to skip",
-          "wu_api_key": "API key - leave blank to skip",
+          "wu_api_key": "Station key (password) - leave blank to skip",
           "wu_interval_min": "Upload interval",
           "_go_back": "← Go back to previous step"
         }
@@ -331,7 +331,7 @@
           "sea_temp_lon": "Sea temperature longitude",
           "enable_wunderground": "Weather Underground upload",
           "wu_station_id": "WU Station ID",
-          "wu_api_key": "WU API key",
+          "wu_api_key": "WU Station key (password)",
           "wu_interval_min": "WU upload interval"
         },
         "data_description": {
@@ -365,7 +365,7 @@
           "sea_temp_lon": "Sea temperature longitude",
           "enable_wunderground": "Weather Underground upload",
           "wu_station_id": "WU Station ID",
-          "wu_api_key": "WU API key",
+          "wu_api_key": "WU Station key (password)",
           "wu_interval_min": "WU upload interval"
         }
       },
@@ -488,7 +488,7 @@
         "description": "{info}",
         "data": {
           "wu_station_id": "Station ID",
-          "wu_api_key": "API key",
+          "wu_api_key": "Station key (password)",
           "wu_interval_min": "Upload interval"
         }
       },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha_ws_core"
-version = "2.0.6"
+version = "2.0.7"
 description = "Weather Station Core - Home Assistant integration for personal weather stations"
 requires-python = ">=3.12"
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -485,3 +485,105 @@ class TestVersionConsistency:
         with open("pyproject.toml") as f:
             content = f.read()
         assert f'version = "{v}"' in content, f"pyproject.toml does not contain version {v!r}"
+
+
+class TestOptionsFlowSourceValidation:
+    """Regression tests for the options flow (issues #70 and #71)."""
+
+    @staticmethod
+    def _make_flow(sources, states):
+        from custom_components.ws_core import config_flow as cf
+
+        class _State:
+            def __init__(self, s):
+                self.state = s
+                self.attributes = {}
+
+        hass = MagicMock()
+        hass.config.latitude = 47.8358
+        hass.config.longitude = 1.9507
+        hass.config.elevation = 100
+        hass.states.get = lambda eid: _State(states[eid]) if eid in states else None
+        hass.states.async_all = lambda: [
+            type("S", (), {"entity_id": e, "attributes": {}})() for e in states
+        ]
+
+        entry = MagicMock()
+        entry.data = {CONF_SOURCES: dict(sources)}
+        entry.options = {}
+
+        class _Flow(cf.WSStationOptionsFlowHandler):
+            pass
+
+        # config_entry is a read-only property on the real OptionsFlow base.
+        _Flow.config_entry = property(lambda self: entry)
+        flow = _Flow()
+        flow.hass = hass
+        flow._opt = {}
+        return flow
+
+    def test_required_sources_opt_validates_without_attribute_error(self):
+        """Issue #70: submitting source sensors in the options flow must not raise.
+
+        ``_validate_numeric_sensor`` used to live only on the config-flow class, so
+        the options flow raised AttributeError -> HA's 'Unknown error occurred'.
+        """
+        from custom_components.ws_core.const import REQUIRED_SOURCES
+
+        sources = {k: f"sensor.{k}" for k in REQUIRED_SOURCES}
+        states = {f"sensor.{k}": "1.0" for k in REQUIRED_SOURCES}
+        flow = self._make_flow(sources, states)
+
+        import asyncio
+
+        res = asyncio.run(flow.async_step_required_sources_opt(dict(sources)))
+        # No exception, advances to the next step with no errors.
+        assert res.get("errors") in (None, {})
+        assert res.get("type") in ("form", None) or res.get("step_id")
+
+        # A missing/non-numeric sensor returns a field error rather than crashing.
+        bad = dict(sources)
+        bad[REQUIRED_SOURCES[0]] = "sensor.does_not_exist"
+        res2 = asyncio.run(flow.async_step_required_sources_opt(bad))
+        assert res2["errors"][REQUIRED_SOURCES[0]] == "entity_not_found"
+
+    def test_options_init_schema_accepts_empty_forecast_entity(self):
+        """Issue #71: the options 'init' schema must validate when no weather entity is set.
+
+        An empty weather EntitySelector default raised 'Entity is neither a valid
+        entity ID nor a valid UUID', blocking the whole dialog.
+        """
+        import asyncio
+
+        from voluptuous import UNDEFINED
+
+        from custom_components.ws_core.const import (
+            CONF_FORECAST_ENTITY,
+            REQUIRED_SOURCES,
+        )
+
+        sources = {k: f"sensor.{k}" for k in REQUIRED_SOURCES}
+        states = {f"sensor.{k}": "1.0" for k in REQUIRED_SOURCES}
+        flow = self._make_flow(sources, states)
+
+        res = asyncio.run(flow.async_step_init(None))
+        schema = res["data_schema"]
+
+        # Build the payload the frontend submits, omitting the (empty) weather entity.
+        user_input = {}
+        for marker in schema.schema:
+            key = marker.schema
+            if key == CONF_FORECAST_ENTITY:
+                continue
+            default = marker.default
+            if callable(default):
+                try:
+                    default = default()
+                except Exception:
+                    default = None
+            if default is UNDEFINED or default is None:
+                continue
+            user_input[key] = default
+
+        # Must not raise vol.Invalid for the empty weather entity.
+        schema(user_input)


### PR DESCRIPTION
## Summary

Fixes three bugs in the options flow (Configure dialog) introduced by v2.0.6:

- **#70** — "Unknown error occurred" when editing source sensors. `_validate_numeric_sensor` only existed on `WSStationConfigFlow`; calling `self._validate_numeric_sensor` from the options flow handler raised `AttributeError`. Moved to a shared module-level helper used by both flows.
- **#71** — "Entity is neither a valid entity ID nor a valid UUID" blocking the whole general settings dialog. The inline `CONF_FORECAST_ENTITY` field had `default=""` which fails `EntitySelector` validation on every form render, even when the user isn't using the HA weather-entity provider. Changed to `suggested_value` so an empty field is simply omitted.
- **#72** (cherry-picks @miczu71's fix from [PR #72](https://github.com/kmich/ha_ws_core/pull/72)) — WU credentials could never be saved (uploads were never sent) because `_validate_wu_credentials` called the read API (`api.weather.com`), which requires a separate 32-char read key. The validator now hits the same PWS upload endpoint (`weatherstation.wunderground.com/weatherstation/updateweatherstation.php`) as the actual uploader in the coordinator. WU field relabelled from "API key" → "Station key (password)" in `strings.json` / `translations/en.json`.

## Changes

- `config_flow.py` — module-level `_validate_numeric_sensor(hass, eid)`, upload-endpoint WU validator, `suggested_value` for forecast entity
- `strings.json` / `translations/en.json` — WU label renames (kept in sync)
- `tests/test_integration.py` — two regression tests for #70 and #71
- Version bumped to **2.0.7** across `manifest.json`, `pyproject.toml`, `diagnostics.py`

## Test plan

- [ ] `pytest tests/test_integration.py::TestOptionsFlowSourceValidation` — 2 new regression tests pass
- [ ] `pytest tests/test_integration.py::TestVersionConsistency` — version consistency across all files
- [ ] `ruff check custom_components/ws_core/` — no lint errors
- [ ] Manual: open Configure on an existing entry, save source sensors → no "Unknown error occurred"
- [ ] Manual: open Configure general settings without a WA weather entity selected → no "Entity is neither a valid entity ID" error
- [ ] Manual: enter a WU station ID + station key → credentials save and uploads are sent

Closes #70
Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)