### PR TITLE
fix: tolerate older HA cores lacking WIND_DIRECTION / MEASUREMENT_ANGLE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Weather Station Core are documented here.
 
+## [2.5.1] - 2026-06-24
+
+### Fixed
+
+- **Compatibility with HA 2024.6 - 2024.12:** `sensor.py` referenced `SensorDeviceClass.WIND_DIRECTION` and `SensorStateClass.MEASUREMENT_ANGLE` (added in HA 2025.1) unconditionally, while the declared minimum is HA 2024.6.0. On those older cores the sensor platform failed to load with `AttributeError`. Both are now resolved defensively, so older cores fall back to a plain numeric `°` wind-direction sensor instead of crashing.
+
+### Internal
+
+- Added `tests/test_sensor_platform.py` (imports the sensor module so HA-version incompatibilities are caught by CI) and `tests/test_migration.py` (covers the v2 -> v3 hemisphere/climate-region slug migration).
+
 ## [2.5.0] - 2026-06-23
 
 ### Added

--- a/custom_components/ws_core/diagnostics.py
+++ b/custom_components/ws_core/diagnostics.py
@@ -56,7 +56,7 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigE
 
     return {
         "title": entry.title,
-        "version": "2.5.0",
+        "version": "2.5.1",
         "entry_data": _redact_coords(dict(entry.data)),
         "entry_options": _redact_coords(dict(entry.options)),
         "sources": sources,

--- a/custom_components/ws_core/manifest.json
+++ b/custom_components/ws_core/manifest.json
@@ -13,5 +13,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/kmich/ha_ws_core/issues",
   "requirements": [],
-  "version": "2.5.0"
+  "version": "2.5.1"
 }

--- a/custom_components/ws_core/sensor.py
+++ b/custom_components/ws_core/sensor.py
@@ -281,6 +281,14 @@ _PRESSURE_FACTORS: dict[str, float] = {"hPa": 1.0, "inHg": 0.02953, "mmHg": 0.75
 _DISTANCE_FACTORS: dict[str, float] = {"km": 1.0, "mi": 0.621371}
 _ALTITUDE_FACTORS: dict[str, float] = {"m": 1.0, "ft": 3.28084}
 
+# SensorDeviceClass.WIND_DIRECTION and SensorStateClass.MEASUREMENT_ANGLE were
+# added in HA 2025.1. We support down to HA 2024.6.0 (see hacs.json), so resolve
+# them defensively: on older cores the wind-direction sensors simply fall back to
+# a plain numeric "°" sensor (no device class / measurement state class) instead
+# of raising AttributeError at import and breaking the whole sensor platform.
+_WIND_DIRECTION_DEVICE_CLASS = getattr(SensorDeviceClass, "WIND_DIRECTION", None)
+_MEASUREMENT_ANGLE_STATE_CLASS = getattr(SensorStateClass, "MEASUREMENT_ANGLE", SensorStateClass.MEASUREMENT)
+
 SENSORS: list[WSSensorDescription] = [
     # =========================================================================
     # CORE MEASUREMENTS
@@ -359,9 +367,9 @@ SENSORS: list[WSSensorDescription] = [
         translation_key="wind_direction",
         name="WS Wind Direction",
         icon="mdi:compass",
-        device_class=SensorDeviceClass.WIND_DIRECTION,
+        device_class=_WIND_DIRECTION_DEVICE_CLASS,
         native_unit="\u00b0",
-        state_class=SensorStateClass.MEASUREMENT_ANGLE,
+        state_class=_MEASUREMENT_ANGLE_STATE_CLASS,
     ),
     WSSensorDescription(
         key=KEY_NORM_RAIN_TOTAL_MM,
@@ -1396,9 +1404,9 @@ SENSORS: list[WSSensorDescription] = [
         translation_key="dominant_wind_direction",
         name="WS Dominant Wind Direction",
         icon="mdi:compass-rose",
-        device_class=SensorDeviceClass.WIND_DIRECTION,
+        device_class=_WIND_DIRECTION_DEVICE_CLASS,
         native_unit="°",
-        state_class=SensorStateClass.MEASUREMENT_ANGLE,
+        state_class=_MEASUREMENT_ANGLE_STATE_CLASS,
         attrs_fn=lambda d: {
             "variability_deg": d.get(KEY_WIND_DIR_VARIABILITY),
         },

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,7 @@ See the [Quickstart](quickstart.md) for a 5-minute installation walkthrough.
 
 ## Project status
 
-- **Version:** 2.5.0 (June 2026)
+- **Version:** 2.5.1 (June 2026)
 - **License:** MIT
 - **Repository:** [github.com/kmich/ha_ws_core](https://github.com/kmich/ha_ws_core)
 - **Issues:** [GitHub Issues](https://github.com/kmich/ha_ws_core/issues)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha_ws_core"
-version = "2.5.0"
+version = "2.5.1"
 description = "Weather Station Core - Home Assistant integration for personal weather stations"
 requires-python = ">=3.12"
 

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,89 @@
+"""Regression tests for config-entry migration (async_migrate_entry).
+
+The v2 -> v3 migration slugs the hemisphere / climate_region values so the
+selectors can be translated (issue #104). This runs on every existing install
+on upgrade to 2.5.0, so it is worth a dedicated guard.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from custom_components.ws_core import async_migrate_entry
+from custom_components.ws_core.const import CONFIG_VERSION
+
+
+def _run_migration(version, data, options=None):
+    """Invoke async_migrate_entry against a mocked hass/entry; return update kwargs."""
+    hass = MagicMock()
+    hass.config.latitude = 37.9
+    hass.config.longitude = 23.7
+
+    captured: dict = {}
+
+    def _update(entry, **kw):
+        captured.update(kw)
+
+    hass.config_entries.async_update_entry = _update
+
+    entry = MagicMock()
+    entry.version = version
+    entry.data = dict(data)
+    entry.options = dict(options or {})
+    entry.entry_id = "test_entry"
+
+    fake_registry = MagicMock()
+    fake_registry.entities.values.return_value = []
+
+    with patch("custom_components.ws_core.er.async_get", return_value=fake_registry):
+        result = asyncio.run(async_migrate_entry(hass, entry))
+
+    return result, captured
+
+
+class TestMigration:
+    def test_v2_slugs_display_values_in_data(self):
+        ok, cap = _run_migration(
+            2, {"hemisphere": "Northern", "climate_region": "Atlantic Europe", "prefix": "ws"}
+        )
+        assert ok is True
+        assert cap["version"] == CONFIG_VERSION
+        assert cap["data"]["hemisphere"] == "northern"
+        assert cap["data"]["climate_region"] == "atlantic_europe"
+
+    def test_v2_slugs_display_values_in_options(self):
+        _, cap = _run_migration(
+            2,
+            {"prefix": "ws"},
+            {"hemisphere": "Southern", "climate_region": "North America West"},
+        )
+        assert cap["options"]["hemisphere"] == "southern"
+        assert cap["options"]["climate_region"] == "north_america_west"
+
+    def test_already_slugged_values_are_left_unchanged(self):
+        # An unknown / already-slug value must pass through untouched (idempotent).
+        _, cap = _run_migration(
+            2, {"hemisphere": "northern", "climate_region": "mediterranean", "prefix": "ws"}
+        )
+        assert cap["data"]["hemisphere"] == "northern"
+        assert cap["data"]["climate_region"] == "mediterranean"
+
+    def test_v1_entry_gets_slug_defaults(self):
+        # v1 -> v2 fills hemisphere from latitude (37.9 -> northern) as a slug.
+        _, cap = _run_migration(1, {"prefix": "ws"})
+        assert cap["data"]["hemisphere"] == "northern"
+        assert cap["data"]["climate_region"] in {
+            "atlantic_europe",
+            "mediterranean",
+            "continental_europe",
+            "scandinavia",
+            "north_america_east",
+            "north_america_west",
+            "australia",
+            "custom",
+        }

--- a/tests/test_sensor_platform.py
+++ b/tests/test_sensor_platform.py
@@ -1,0 +1,46 @@
+"""Regression tests for the sensor platform module import.
+
+Importing ``sensor.py`` exercises module-level references to Home Assistant
+enums. ``SensorDeviceClass.WIND_DIRECTION`` and
+``SensorStateClass.MEASUREMENT_ANGLE`` only exist in HA 2025.1+, but the
+integration supports down to HA 2024.6.0 (hacs.json). These were previously
+referenced unconditionally, so on an older core importing the module raised
+``AttributeError`` and the whole sensor platform failed to load. No test
+imported ``sensor.py``, so CI never caught it.
+
+This test imports the module so any such HA-version incompatibility is caught
+by the CI "Tests" job, which runs against a pinned HA version.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def test_sensor_module_imports_and_builds_descriptions():
+    from custom_components.ws_core import sensor
+
+    assert sensor.SENSORS, "SENSORS list should not be empty"
+    keys = {s.key for s in sensor.SENSORS}
+    # Both wind-direction sensors must be present regardless of HA version.
+    from custom_components.ws_core.const import KEY_DOMINANT_WIND_DIR, KEY_NORM_WIND_DIR_DEG
+
+    assert KEY_NORM_WIND_DIR_DEG in keys
+    assert KEY_DOMINANT_WIND_DIR in keys
+
+
+def test_wind_direction_classes_resolve_without_crashing():
+    """The defensive lookups must always yield a usable value."""
+    from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+
+    from custom_components.ws_core import sensor
+
+    # device class is either the real enum member (new HA) or None (old HA).
+    assert sensor._WIND_DIRECTION_DEVICE_CLASS is None or isinstance(
+        sensor._WIND_DIRECTION_DEVICE_CLASS, SensorDeviceClass
+    )
+    # state class always falls back to a real member, never missing.
+    assert isinstance(sensor._MEASUREMENT_ANGLE_STATE_CLASS, SensorStateClass)


### PR DESCRIPTION
## Problem
`custom_components/ws_core/sensor.py` referenced `SensorDeviceClass.WIND_DIRECTION` and `SensorStateClass.MEASUREMENT_ANGLE` unconditionally (the two wind-direction sensors). Both were added in **HA 2025.1**, but `hacs.json` declares a minimum of **HA 2024.6.0**. On cores between 2024.6 and 2024.12, importing `sensor.py` raises `AttributeError: type object 'SensorDeviceClass' has no attribute 'WIND_DIRECTION'`, which makes the **entire sensor platform fail to load**.

This went unnoticed because no test imported `sensor.py`; it surfaced when a v2.5.0 test imported the module against the CI-pinned HA version.

## Fix
Resolve both symbols defensively at module load:

```python
_WIND_DIRECTION_DEVICE_CLASS = getattr(SensorDeviceClass, "WIND_DIRECTION", None)
_MEASUREMENT_ANGLE_STATE_CLASS = getattr(SensorStateClass, "MEASUREMENT_ANGLE", SensorStateClass.MEASUREMENT)
```

- **HA 2025.1+**: behaviour unchanged (real device/state classes).
- **HA 2024.6–2024.12**: the wind-direction sensors degrade to a plain numeric `°` sensor (`device_class=None`, `state_class=MEASUREMENT`) instead of crashing.

This keeps the code consistent with the declared `hacs.json` minimum (rather than forcing a higher minimum on users).

## Regression guard
Adds `tests/test_sensor_platform.py`, which **imports the sensor module** (and asserts both wind-direction sensors are present). The CI "Tests" job runs against a pinned HA version that lacks these APIs, so this test fails without the fix and passes with it - catching this class of incompatibility going forward.

## Verification
- ruff + ruff format clean
- 255 tests pass locally (HA 2026.2.3)
- dashboard entity validator passes
- The real proof is CI here, which runs the older pinned HA

🤖 Generated with [Claude Code](https://claude.com/claude-code)