### PR TITLE
Update config flow

### DIFF
--- a/custom_components/ws_core/config_flow.py
+++ b/custom_components/ws_core/config_flow.py
@@ -335,6 +335,31 @@ async def _fetch_vigicrues_station_options(lat: float, lon: float) -> list[dict]
     return options
 
 
+def _ensure_selected_stations_present(options: list[dict], existing: list[dict]) -> list[dict]:
+    """Make sure previously-selected stations are always selectable.
+
+    `_fetch_vigicrues_station_options` only returns stations within a fixed
+    50 km radius (top 20 results) of the *current* lat/lon. If the forecast
+    location changes, or the API/network is briefly unavailable, a
+    previously-saved station can fall outside that result set. When that
+    happens the SelectSelector silently can't show it as selected, even
+    though `current_codes` still contains its code - it just looks empty
+    in the UI. Re-inject any missing saved stations using their stored
+    name/river so they always remain a valid, selected option.
+    """
+    known_codes = {o["value"] for o in options}
+    for station in existing:
+        code = (station.get("code") or "").strip()
+        if not code or code in known_codes:
+            continue
+        name = station.get("name") or code
+        river = station.get("river") or ""
+        label = f"{name} ({river})" if river else name
+        options.append({"value": code, "label": f"{label} (saved)", "_name": name, "_river": river})
+        known_codes.add(code)
+    return options
+
+
 def _guess_defaults(hass: HomeAssistant) -> dict[str, str]:
     """Best-effort auto-detection of sensor entity IDs by name pattern."""
     guess: dict[str, str] = {}
@@ -1132,6 +1157,8 @@ class WSStationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return await self.async_step_pollen()
             if self._data.get(CONF_ENABLE_SOLAR_FORECAST):
                 return await self.async_step_solar_forecast()
+            if self._data.get(CONF_ENABLE_VIGICRUES):
+                return await self.async_step_vigicrues_station()
             return await self._next_v2_step()
 
         default_lat = getattr(self.hass.config, "latitude", 0.0) or 0.0
@@ -1195,6 +1222,8 @@ class WSStationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     return await self.async_step_pollen()
                 if self._data.get(CONF_ENABLE_SOLAR_FORECAST):
                     return await self.async_step_solar_forecast()
+                if self._data.get(CONF_ENABLE_VIGICRUES):
+                    return await self.async_step_vigicrues_station()
                 return await self._next_v2_step()
 
         existing_station = self._data.get(CONF_WU_STATION_ID, "")
@@ -1233,6 +1262,8 @@ class WSStationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return await self.async_step_pollen()
             if self._data.get(CONF_ENABLE_SOLAR_FORECAST):
                 return await self.async_step_solar_forecast()
+            if self._data.get(CONF_ENABLE_VIGICRUES):
+                return await self.async_step_vigicrues_station()
             return await self._next_v2_step()
 
         return self._show_step(
@@ -1262,6 +1293,8 @@ class WSStationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return back
             if self._data.get(CONF_ENABLE_SOLAR_FORECAST):
                 return await self.async_step_solar_forecast()
+            if self._data.get(CONF_ENABLE_VIGICRUES):
+                return await self.async_step_vigicrues_station()
             return await self._next_v2_step()
 
         return self._show_step(
@@ -1348,7 +1381,6 @@ class WSStationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         lat = self._data.get(CONF_FORECAST_LAT) or getattr(self.hass.config, "latitude", 0.0) or 0.0
         lon = self._data.get(CONF_FORECAST_LON) or getattr(self.hass.config, "longitude", 0.0) or 0.0
         options = await _fetch_vigicrues_station_options(lat, lon)
-        self._vigicrues_station_options = options
 
         # Pre-select previously chosen stations (migrate legacy single-code if needed)
         existing: list[dict] = self._data.get(CONF_VIGICRUES_STATIONS) or []
@@ -1356,6 +1388,8 @@ class WSStationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             legacy_code = (self._data.get(CONF_VIGICRUES_STATION_CODE) or "").strip()
             if legacy_code:
                 existing = [{"code": legacy_code}]
+        options = _ensure_selected_stations_present(options, existing)
+        self._vigicrues_station_options = options
         current_codes = [s["code"] for s in existing if s.get("code")]
 
         return self._show_step(
@@ -2866,7 +2900,6 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
             or 0.0
         )
         options = await _fetch_vigicrues_station_options(lat, lon)
-        self._vigicrues_station_options_opt = options
 
         # Pre-select previously chosen stations (migrate legacy single-code if needed)
         existing: list[dict] = self._opt.get(CONF_VIGICRUES_STATIONS) or g(CONF_VIGICRUES_STATIONS, []) or []
@@ -2876,6 +2909,8 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
             ).strip()
             if legacy_code:
                 existing = [{"code": legacy_code}]
+        options = _ensure_selected_stations_present(options, existing)
+        self._vigicrues_station_options_opt = options
         current_codes = [s["code"] for s in existing if s.get("code")]
 
         return self.async_show_form(


### PR DESCRIPTION
MADE WITH CLAUDE 

*Bug 1: Vigicrues step skipped in config flow under certain conditions*

Summary
In config_flow.py, the Vigicrues hydrometric station picker (async_step_vigicrues_station) is silently skipped during initial setup (config flow) whenever Vigicrues is enabled together with certain other features — even though CONF_ENABLE_VIGICRUES is True. The options flow is unaffected.

Root cause
The post-features navigation is a hardcoded linear chain: each step explicitly checks the next enabled feature and calls its step function directly, rather than iterating over enabled features dynamically (as the options flow does via _opt_next_after). When Vigicrues support was added, the check if self._data.get(CONF_ENABLE_VIGICRUES): return await self.async_step_vigicrues_station() was only inserted in async_step_solar_forecast. Four earlier steps — async_step_sea_temp, async_step_wunderground, async_step_air_quality, and async_step_pollen — fell through directly to _next_v2_step() without ever checking CONF_ENABLE_VIGICRUES.

Effect
If a user enabled Vigicrues together with Sea Temperature, Wunderground upload, Air Quality, or Pollen — but not Solar Forecast — the flow jumped straight past the Vigicrues station picker into the upload-service steps, silently falling back to auto-detecting the nearest station instead of letting the user choose.

Fix
Added the missing if self._data.get(CONF_ENABLE_VIGICRUES): return await self.async_step_vigicrues_station() check to the four affected steps, right before their existing fallback to _next_v2_step().

Suggested longer-term improvement
Worth considering refactoring this whole post-features chain into the same ordered-list pattern already used by the options flow's _opt_next_after. That would prevent this class of bug from recurring whenever a new optional feature is inserted into the chain.

*Bug 2: Previously-selected Vigicrues station(s) can disappear from the picker*

Summary
When reopening the Vigicrues station step (in either config flow or options flow), a station the user had already selected can appear to be missing/deselected in the dropdown, even though it's correctly stored in the config entry.

Root cause
_fetch_vigicrues_station_options(lat, lon) queries the Hub'Eau API with a fixed 50 km radius and a max of 20 results around the current lat/lon. The previously-saved station's code is correctly computed into current_codes and passed as the SelectSelector's default, but Home Assistant's SelectSelector can only show a value as selected if it's also present in the options list it's given. If the saved station falls outside the 50 km/20-result window returned by the API (e.g. the forecast location was moved, or the API had a transient issue), it's silently absent from options, and the selection looks empty in the UI — even though nothing was actually lost in storage.
This affects both async_step_vigicrues_station (config flow) and async_step_vigicrues_station_opt (options flow), since both call the same helper.

Fix
Added a new helper, _ensure_selected_stations_present(options, existing), which re-injects any previously-saved station into the options list (using its stored name/river) if the API didn't return it. It's labeled "... (saved)" so it's clear to the user it's not part of the live nearby-stations list. Called right after fetching options, in both the config flow and options flow station steps.