### PR TITLE
fix(translations): fix fr.json structure causing all French strings to be ignored

### DIFF
--- a/custom_components/ws_core/translations/fr.json
+++ b/custom_components/ws_core/translations/fr.json
@@ -502,8 +502,9 @@
           "enable_lightning": "Calcule la distance estimée et la fréquence des impacts de foudre détectés à proximité.",
           "enable_indoor": "Permet de lier vos sondes intérieures pour affiner les calculs de confort thermique global.",
           "enable_soil": "Calcule le besoin en eau des plantes, l'évaporation et suit vos sondes d'humidité du sol."
-       }, 
-       "indoor_rooms_opt": {
+        }
+      },
+      "indoor_rooms_opt": {
         "title": "Capteurs intérieurs des différentes pièces",
         "description": "Sélectionnez un capteur de température par pièce pour générer un capteur d'écart de température intérieur/extérieur dédié.",
         "data": {
@@ -2547,5 +2548,4 @@
       }
     }
   }
-}
 }


### PR DESCRIPTION
## Summary

- `indoor_rooms_opt` and all subsequent options flow steps were nested inside `features_opt.data_description` instead of being siblings of `features_opt` in `options.step`
- Home Assistant silently discards a malformed translation schema and falls back to English, which is exactly what was reported in #111
- Also removes a stale extra `}` at the end of the file left from before PR #109

The JSON was syntactically valid (which is why it was hard to spot), but structurally wrong at the schema level HA validates against.

## Test plan

- [ ] Reload the integration with a French HA instance and confirm options flow labels appear in French
- [ ] Confirm `python -c "import json; json.load(open('custom_components/ws_core/translations/fr.json', encoding='utf-8'))"` exits cleanly

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)