### PR TITLE
fix(translations): correct inverted French notifications switch label (#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Weather Station Core are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- **French notification switch was inverted (issue #114):** the `ws_suppress_notifications` switch read "Bloquer les notifications HA" (Block) in French while every other language and the underlying logic use "Enable HA Notifications" semantics. French users who turned the switch ON to block notifications were actually enabling them, so HA Repairs alerts (e.g. stale-sensor warnings) kept appearing. The French label is now "Activer les notifications HA", consistent with the switch behaviour and all other locales.
+
 ## [2.5.2] - 2026-06-25
 
 ### Fixed

--- a/custom_components/ws_core/translations/fr.json
+++ b/custom_components/ws_core/translations/fr.json
@@ -2379,7 +2379,7 @@
         "name": "Prévision immédiate des précipitations"
       },
       "ws_suppress_notifications": {
-        "name": "Bloquer les notifications HA"
+        "name": "Activer les notifications HA"
       },
       "ws_enable_degree_days": {
         "name": "Degrés-jours & humidité du feuillage"


### PR DESCRIPTION
## Description

Fixes the French label of the `ws_suppress_notifications` switch, which was the opposite of its actual behaviour.

The switch uses `inverted=True` logic (`switch.py`): **switch ON = notifications enabled** (`suppress_notifications=False`). English and every other locale (de/es/it/nl/pl/pt) label it **"Enable HA Notifications"**, matching the behaviour. French alone read **"Bloquer les notifications HA"** ("Block HA notifications") - the opposite meaning.

As a result, a French user who turned the switch **ON to block** notifications was actually setting `suppress=False` and **enabling** them. HA Repairs alerts (e.g. the stale-sensor warning) kept appearing, which is exactly the behaviour reported.

The coordinator gating in `coordinator.py` (`if self.suppress_notifications: delete all issues`) was correct all along; only the French label was wrong.

## Related Issue

Closes #114

## Motivation and Context

The reporter writes in French and followed the French label, getting the inverse of the intended effect.

## How Has This Been Tested?

- `python -m pytest -q` → 259 passed
- `fr.json` validated as parseable JSON
- Verified the label is now consistent with the `inverted=True` switch logic and all other locales

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly (if needed)
- [ ] I have added tests to cover my changes (if applicable)
- [x] All new and existing tests passed
- [x] I have updated CHANGELOG.md with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)