### PR TITLE
chore: release 2.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Weather Station Core are documented here.
 
-## [Unreleased]
+## [2.5.5] - 2026-06-30
 
 ### Fixed
 

--- a/custom_components/ws_core/diagnostics.py
+++ b/custom_components/ws_core/diagnostics.py
@@ -56,7 +56,7 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigE
 
     return {
         "title": entry.title,
-        "version": "2.5.4",
+        "version": "2.5.5",
         "entry_data": _redact_coords(dict(entry.data)),
         "entry_options": _redact_coords(dict(entry.options)),
         "sources": sources,

--- a/custom_components/ws_core/manifest.json
+++ b/custom_components/ws_core/manifest.json
@@ -13,5 +13,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/kmich/ha_ws_core/issues",
   "requirements": [],
-  "version": "2.5.4"
+  "version": "2.5.5"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha_ws_core"
-version = "2.5.4"
+version = "2.5.5"
 description = "Weather Station Core - Home Assistant integration for personal weather stations"
 requires-python = ">=3.12"
 


### PR DESCRIPTION
Release 2.5.5.

Bumps version across `manifest.json`, `pyproject.toml`, and `diagnostics.py`, and promotes the `Unreleased` CHANGELOG section to `2.5.5`.

### Included
- **#113** - thunderstorm risk sensor now reports `%` (0-100 index)
- **#114** - corrected the inverted French label on the notifications switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)