### PR TITLE
feat(indoor): named multi-room indoor monitoring with per-room comfort (#115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Weather Station Core are documented here.
 
+## [2.6.0] - 2026-06-30
+
+### Added
+
+- **Multiple indoor rooms with per-room comfort (issue #115):** the indoor monitoring feature now supports any number of named rooms, each with its own temperature, humidity and/or CO2 sensor. Every room gets dedicated sensors - indoor/outdoor temperature delta, humidity (with delta), CO2, and a composite comfort score (0-100) - created only for the metrics you assign. Rooms are managed from a new add/edit/remove screen in the options flow (Configure -> Indoor Rooms). Existing temperature-only rooms from 2.0.5 are migrated automatically (config schema v3 -> v4) and keep their delta sensors. Indoor comfort scoring is shared between the main indoor group and rooms via a single algorithm.
+
 ## [2.5.5] - 2026-06-30
 
 ### Fixed

--- a/custom_components/ws_core/__init__.py
+++ b/custom_components/ws_core/__init__.py
@@ -22,6 +22,7 @@ from .const import (
     CONF_CAL_WIND_MS,
     CONF_CLIMATE_REGION,
     CONF_HEMISPHERE,
+    CONF_INDOOR_ROOMS,
     CONFIG_VERSION,
     DEFAULT_CLIMATE_REGION,
     DEFAULT_HEMISPHERE,
@@ -29,6 +30,7 @@ from .const import (
     DEPRECATED_KEYS_V030,
     DOMAIN,
     PLATFORMS,
+    normalize_indoor_rooms,
 )
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
@@ -54,6 +56,9 @@ async def async_migrate_entry(hass: HomeAssistant, entry) -> bool:
     v2 -> v3 (v2.5.0): Slug hemisphere/climate_region values so they can be
         translated in the UI (issue #104), e.g. "Atlantic Europe" ->
         "atlantic_europe", "Northern" -> "northern".
+    v3 -> v4 (v2.6.0): Upconvert CONF_INDOOR_ROOMS from a bare list of
+        temperature-sensor entity_ids to the named-room dict shape
+        (issue #115).
     """
     _LOGGER.info("Migrating ws_core config entry from version %s to %s", entry.version, CONFIG_VERSION)
 
@@ -140,6 +145,17 @@ async def async_migrate_entry(hass: HomeAssistant, entry) -> bool:
                 store[CONF_HEMISPHERE] = _HEMISPHERE_SLUGS[store[CONF_HEMISPHERE]]
             if store.get(CONF_CLIMATE_REGION) in _CLIMATE_REGION_SLUGS:
                 store[CONF_CLIMATE_REGION] = _CLIMATE_REGION_SLUGS[store[CONF_CLIMATE_REGION]]
+
+    # ---- v3 -> v4 (v2.6.0): named indoor rooms ----
+    if entry.version < 4:
+        for store in (new_data, new_options):
+            if CONF_INDOOR_ROOMS in store:
+                before = store[CONF_INDOOR_ROOMS]
+                store[CONF_INDOOR_ROOMS] = normalize_indoor_rooms(before)
+                _LOGGER.info(
+                    "v2.6.0 migration: normalized %d indoor room(s) to named-room shape",
+                    len(store[CONF_INDOOR_ROOMS]),
+                )
 
     hass.config_entries.async_update_entry(
         entry,

--- a/custom_components/ws_core/algorithms.py
+++ b/custom_components/ws_core/algorithms.py
@@ -2723,3 +2723,45 @@ def calculate_utci(ta: float, tr: float, va: float, rh: float) -> float | None:
     )
 
     return round(float(ta) + utci_approx, 1)
+
+
+def indoor_comfort_score(
+    temp_c: float | None,
+    humidity_pct: float | None,
+    co2_ppm: float | None,
+) -> int | None:
+    """Composite indoor comfort score (0-100) from temperature, RH and CO2.
+
+    Starts at 100 and applies penalties for values outside comfortable bands:
+      - CO2 (ppm):  >1000 -10, >1500 -25, >2000 -40
+      - Temp (C):   outside 18-26 -10, outside 16-28 -20
+      - RH (%):     outside 40-60 -10, outside 30-70 -20
+
+    Returns ``None`` when no inputs are available so callers can skip the
+    sensor entirely rather than report a misleading perfect score.
+    """
+    if temp_c is None and humidity_pct is None and co2_ppm is None:
+        return None
+
+    score = 100
+    if co2_ppm is not None:
+        co2 = float(co2_ppm)
+        if co2 > 2000:
+            score -= 40
+        elif co2 > 1500:
+            score -= 25
+        elif co2 > 1000:
+            score -= 10
+    if temp_c is not None:
+        t = float(temp_c)
+        if t < 16 or t > 28:
+            score -= 20
+        elif t < 18 or t > 26:
+            score -= 10
+    if humidity_pct is not None:
+        rh = float(humidity_pct)
+        if rh < 30 or rh > 70:
+            score -= 20
+        elif rh < 40 or rh > 60:
+            score -= 10
+    return max(0, min(100, score))

--- a/custom_components/ws_core/config_flow.py
+++ b/custom_components/ws_core/config_flow.py
@@ -15,6 +15,7 @@ The Options flow (Configure button) exposes all settings for post-install change
 from __future__ import annotations
 
 import logging
+import uuid
 from typing import Any
 
 import aiohttp
@@ -240,6 +241,7 @@ from .const import (
     VALID_TEMP_MIN_C,
     VALID_WIND_GUST_MAX_MS,
     WIND_UNIT_OPTIONS,
+    normalize_indoor_rooms,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -2328,22 +2330,107 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
             last_step=False,
         )
 
-    async def async_step_indoor_rooms_opt(self, user_input: dict[str, Any] | None = None):
-        """Select additional indoor temperature sensors for per-room delta sensors."""
-        g = self._get
-        if user_input is not None:
-            rooms = user_input.get(CONF_INDOOR_ROOMS) or []
-            self._opt[CONF_INDOOR_ROOMS] = list(rooms)
-            return await self.async_step_upload_services_opt()
+    # ------------------------------------------------------------------
+    # Named indoor rooms (v2.6.0; issue #115) - add / edit / remove hub
+    # ------------------------------------------------------------------
+    def _rooms_working_copy(self) -> list[dict]:
+        """Return (initializing if needed) the in-progress room list."""
+        if CONF_INDOOR_ROOMS not in self._opt:
+            self._opt[CONF_INDOOR_ROOMS] = normalize_indoor_rooms(self._get(CONF_INDOOR_ROOMS, []))
+        return self._opt[CONF_INDOOR_ROOMS]
 
-        current = list(g(CONF_INDOOR_ROOMS, []) or [])
+    def _room_form_schema(self, src: dict | None) -> vol.Schema:
+        src = src or {}
+        sensor_sel = selector.EntitySelector(selector.EntitySelectorConfig(domain="sensor"))
+        schema: dict[Any, Any] = {
+            vol.Required("name", default=src.get("name", "")): selector.TextSelector(),
+        }
+        for field in ("temp", "humidity", "co2"):
+            cur = src.get(field)
+            key = vol.Optional(field, default=cur) if cur else vol.Optional(field)
+            schema[key] = sensor_sel
+        return vol.Schema(schema)
+
+    async def async_step_indoor_rooms_opt(self, user_input: dict[str, Any] | None = None):
+        """Hub menu for managing named indoor rooms."""
+        rooms = self._rooms_working_copy()
+        menu_options = ["room_add"]
+        if rooms:
+            menu_options += ["room_edit", "room_remove"]
+        menu_options.append("room_done")
+        return self.async_show_menu(step_id="indoor_rooms_opt", menu_options=menu_options)
+
+    async def async_step_room_done(self, user_input: dict[str, Any] | None = None):
+        return await self.async_step_upload_services_opt()
+
+    async def async_step_room_add(self, user_input: dict[str, Any] | None = None):
+        self._edit_rid: str | None = None
+        return await self.async_step_room_form()
+
+    async def async_step_room_edit(self, user_input: dict[str, Any] | None = None):
+        rooms = self._rooms_working_copy()
+        if user_input is not None:
+            self._edit_rid = user_input["room"]
+            return await self.async_step_room_form()
+        options = [{"value": r["id"], "label": r["name"]} for r in rooms]
         return self.async_show_form(
-            step_id="indoor_rooms_opt",
+            step_id="room_edit",
             data_schema=vol.Schema(
                 {
-                    vol.Optional(CONF_INDOOR_ROOMS, default=current): selector.EntitySelector(
-                        selector.EntitySelectorConfig(domain="sensor", multiple=True)
-                    ),
+                    vol.Required("room"): selector.SelectSelector(
+                        selector.SelectSelectorConfig(options=options, mode=selector.SelectSelectorMode.DROPDOWN)
+                    )
+                }
+            ),
+            last_step=False,
+        )
+
+    async def async_step_room_form(self, user_input: dict[str, Any] | None = None):
+        rooms = self._rooms_working_copy()
+        editing = next((r for r in rooms if r["id"] == self._edit_rid), None) if self._edit_rid else None
+        if user_input is not None:
+            name = (user_input.get("name") or "").strip()
+            if not name:
+                return self.async_show_form(
+                    step_id="room_form",
+                    data_schema=self._room_form_schema({**(editing or {}), **user_input}),
+                    errors={"name": "room_name_required"},
+                    last_step=False,
+                )
+            room = {
+                "id": editing["id"] if editing else uuid.uuid4().hex[:8],
+                "name": name,
+                "temp": user_input.get("temp") or None,
+                "humidity": user_input.get("humidity") or None,
+                "co2": user_input.get("co2") or None,
+            }
+            if editing:
+                self._opt[CONF_INDOOR_ROOMS] = [room if r["id"] == editing["id"] else r for r in rooms]
+            else:
+                self._opt[CONF_INDOOR_ROOMS] = [*rooms, room]
+            return await self.async_step_indoor_rooms_opt()
+        return self.async_show_form(
+            step_id="room_form",
+            data_schema=self._room_form_schema(editing),
+            last_step=False,
+        )
+
+    async def async_step_room_remove(self, user_input: dict[str, Any] | None = None):
+        rooms = self._rooms_working_copy()
+        if user_input is not None:
+            to_remove = set(user_input.get("rooms") or [])
+            self._opt[CONF_INDOOR_ROOMS] = [r for r in rooms if r["id"] not in to_remove]
+            return await self.async_step_indoor_rooms_opt()
+        options = [{"value": r["id"], "label": r["name"]} for r in rooms]
+        return self.async_show_form(
+            step_id="room_remove",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional("rooms", default=[]): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=options, multiple=True, mode=selector.SelectSelectorMode.LIST
+                        )
+                    )
                 }
             ),
             last_step=False,

--- a/custom_components/ws_core/const.py
+++ b/custom_components/ws_core/const.py
@@ -1,5 +1,7 @@
 """Constants for Weather Station Core."""
 
+from typing import Any
+
 DOMAIN = "ws_core"
 
 PLATFORMS = ["sensor", "binary_sensor", "weather", "select", "switch", "number", "event"]
@@ -358,7 +360,7 @@ DRIFT_STUCK_BUCKET_SAMPLES: int = 240  # 4-hour rolling window
 DRIFT_STUCK_BUCKET_MIN_RATE: float = 0.1  # mm/h minimum to count as non-zero
 DRIFT_STUCK_RATE_RANGE_MAX: float = 0.1  # mm/h max spread to flag as stuck
 
-CONFIG_VERSION = 3
+CONFIG_VERSION = 4
 
 # Alert hysteresis: ticks above/below threshold before state changes
 ALERT_DEBOUNCE_ON_TICKS: int = 2  # consecutive ticks above threshold → fire
@@ -764,9 +766,77 @@ KEY_INDOOR_TEMP_DELTA = "indoor_temp_delta_c"
 KEY_INDOOR_HUMIDITY_DELTA = "indoor_humidity_delta_pct"
 KEY_INDOOR_COMFORT = "indoor_comfort"  # composite score
 
-# Multiple indoor rooms: each entry is a temp sensor entity_id; one delta sensor is created per room
+# Multiple indoor rooms (v2.6.0). Each entry is a room dict:
+#   {"id": str, "name": str, "temp": eid|None, "humidity": eid|None, "co2": eid|None}
+# The stable "id" backs the per-room sensor unique_ids so renaming a room does
+# not churn entities. Legacy installs stored a bare list of temp-sensor
+# entity_ids; async_migrate_entry (v3 -> v4) upconverts them to this shape.
 CONF_INDOOR_ROOMS = "indoor_rooms"
-KEY_INDOOR_ROOMS_DATA = "indoor_rooms_data"  # dict[entity_id, {"temp_c": float, "delta_c": float}]
+# Per-room data keyed by room id:
+#   {room_id: {"name", "temp_c", "delta_c", "humidity_pct", "humidity_delta_pct",
+#              "co2_ppm", "comfort"}}
+KEY_INDOOR_ROOMS_DATA = "indoor_rooms_data"
+
+
+def _room_slug(text: str) -> str:
+    """Lowercase, ASCII-ish slug for room ids derived from names/entity_ids."""
+    out = []
+    for ch in (text or "").strip().lower():
+        if ch.isalnum():
+            out.append(ch)
+        elif ch in (" ", "-", ".", "_"):
+            out.append("_")
+    slug = "".join(out).strip("_")
+    while "__" in slug:
+        slug = slug.replace("__", "_")
+    return slug or "room"
+
+
+def normalize_indoor_rooms(raw: Any) -> list[dict]:
+    """Coerce the stored CONF_INDOOR_ROOMS value into the v2.6.0 room-dict shape.
+
+    Accepts either the legacy ``list[str]`` of temperature-sensor entity_ids or
+    the current ``list[dict]``. Always returns a list of dicts with at least
+    ``id`` and ``name`` populated; missing sensor slots are ``None``. Room ids
+    are de-duplicated so per-room entity unique_ids stay distinct.
+    """
+    rooms: list[dict] = []
+    seen_ids: set[str] = set()
+    for item in raw or []:
+        if isinstance(item, str):
+            # Legacy: a bare temperature-sensor entity_id.
+            eid = item
+            base = eid.split(".", 1)[-1] if "." in eid else eid
+            room = {
+                "id": _room_slug(base),
+                "name": base.replace("_", " ").title(),
+                "temp": eid,
+                "humidity": None,
+                "co2": None,
+            }
+        elif isinstance(item, dict):
+            name = item.get("name") or ""
+            rid = item.get("id") or _room_slug(name) or _room_slug(item.get("temp") or "")
+            room = {
+                "id": rid,
+                "name": name or (rid.replace("_", " ").title() if rid else "Room"),
+                "temp": item.get("temp") or None,
+                "humidity": item.get("humidity") or None,
+                "co2": item.get("co2") or None,
+            }
+        else:
+            continue
+        rid = room["id"] or "room"
+        if rid in seen_ids:
+            suffix = 2
+            while f"{rid}_{suffix}" in seen_ids:
+                suffix += 1
+            rid = f"{rid}_{suffix}"
+            room["id"] = rid
+        seen_ids.add(rid)
+        rooms.append(room)
+    return rooms
+
 
 # ---------------------------------------------------------------------------
 # v2.1 - Soil sensor group (opt-in)

--- a/custom_components/ws_core/coordinator.py
+++ b/custom_components/ws_core/coordinator.py
@@ -100,6 +100,7 @@ from .algorithms import (
     format_rain_display,
     get_condition_severity,
     humidity_level,
+    indoor_comfort_score,
     least_squares_pressure_trend,
     linear_regression_slope,
     moon_next_phase_days,
@@ -520,6 +521,7 @@ from .const import (
     VALID_TEMP_MAX_C,
     VALID_TEMP_MIN_C,
     WIND_SMOOTH_ALPHA,
+    normalize_indoor_rooms,
 )
 from .models import WsData
 from .providers import get_provider
@@ -722,8 +724,10 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Previous indoor readings for stuck-value detection
         self._indoor_temp_prev: float | None = None
         self._indoor_hum_prev: float | None = None
-        # Per-room temperature sensors for multi-room delta support
-        self._indoor_room_temps: list[str] = list(_get(CONF_INDOOR_ROOMS, []) or [])
+        # Named indoor rooms (v2.6.0). Normalized to the room-dict shape so the
+        # coordinator tolerates both legacy list[str] and the new model even
+        # before async_migrate_entry has run.
+        self._indoor_rooms: list[dict] = normalize_indoor_rooms(_get(CONF_INDOOR_ROOMS, []))
 
         # v2.0: lightning sensor integration
         self.lightning_enabled = bool(_get(CONF_ENABLE_LIGHTNING, DEFAULT_ENABLE_LIGHTNING))
@@ -2231,44 +2235,61 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if indoor_co2_raw is not None:
             data[KEY_INDOOR_CO2_PPM] = round(float(indoor_co2_raw))
 
-        # Composite indoor comfort: penalty for CO₂ > 1000, temp outside 18-24°C, RH outside 40-60%
-        score = 100
-        if indoor_co2_raw is not None:
-            co2 = float(indoor_co2_raw)
-            if co2 > 2000:
-                score -= 40
-            elif co2 > 1500:
-                score -= 25
-            elif co2 > 1000:
-                score -= 10
-        if indoor_temp_raw is not None:
-            indoor_tc_f = data.get(KEY_INDOOR_TEMP_C, 20.0)
-            if indoor_tc_f < 16 or indoor_tc_f > 28:
-                score -= 20
-            elif indoor_tc_f < 18 or indoor_tc_f > 26:
-                score -= 10
-        if indoor_hum_raw is not None:
-            rh_i = float(indoor_hum_raw)
-            if rh_i < 30 or rh_i > 70:
-                score -= 20
-            elif rh_i < 40 or rh_i > 60:
-                score -= 10
-        data[KEY_INDOOR_COMFORT] = max(0, min(100, score))
+        # Composite indoor comfort (shared scoring with per-room comfort below).
+        comfort = indoor_comfort_score(
+            data.get(KEY_INDOOR_TEMP_C) if indoor_temp_raw is not None else None,
+            float(indoor_hum_raw) if indoor_hum_raw is not None else None,
+            float(indoor_co2_raw) if indoor_co2_raw is not None else None,
+        )
+        if comfort is not None:
+            data[KEY_INDOOR_COMFORT] = comfort
 
-        # Per-room temperature deltas (multi-room support, v2.0.5)
-        if self._indoor_room_temps:
+        # Per-room indoor monitoring (named rooms, v2.6.0; issue #115).
+        # Each room may carry temp / humidity / CO2 sensors; we derive
+        # outdoor-relative deltas and a per-room comfort score.
+        if self._indoor_rooms:
             outdoor_tc = data.get(KEY_NORM_TEMP_C)
+            outdoor_rh = data.get(KEY_NORM_HUMIDITY)
             rooms: dict[str, dict] = {}
-            for eid in self._indoor_room_temps:
-                val = self._num(self.hass, eid)
-                if val is None:
+            for room in self._indoor_rooms:
+                rid = room.get("id")
+                if not rid:
                     continue
-                unit = self._uom(self.hass, eid)
-                tc = round(self._to_celsius(float(val), unit), 2)
-                room_data: dict[str, Any] = {"temp_c": tc}
-                if outdoor_tc is not None:
-                    room_data["delta_c"] = round(tc - float(outdoor_tc), 2)
-                rooms[eid] = room_data
+                rd: dict[str, Any] = {"name": room.get("name") or rid}
+
+                temp_eid = room.get("temp")
+                tc = None
+                if temp_eid:
+                    val = self._num(self.hass, temp_eid)
+                    if val is not None:
+                        tc = round(self._to_celsius(float(val), self._uom(self.hass, temp_eid)), 2)
+                        rd["temp_c"] = tc
+                        if outdoor_tc is not None:
+                            rd["delta_c"] = round(tc - float(outdoor_tc), 2)
+
+                hum_eid = room.get("humidity")
+                rh = None
+                if hum_eid:
+                    hval = self._num(self.hass, hum_eid)
+                    if hval is not None:
+                        rh = round(float(hval), 2)
+                        rd["humidity_pct"] = rh
+                        if outdoor_rh is not None:
+                            rd["humidity_delta_pct"] = round(rh - float(outdoor_rh), 2)
+
+                co2_eid = room.get("co2")
+                co2 = None
+                if co2_eid:
+                    cval = self._num(self.hass, co2_eid)
+                    if cval is not None:
+                        co2 = round(float(cval))
+                        rd["co2_ppm"] = co2
+
+                room_comfort = indoor_comfort_score(tc, rh, co2)
+                if room_comfort is not None:
+                    rd["comfort"] = room_comfort
+
+                rooms[rid] = rd
             if rooms:
                 data[KEY_INDOOR_ROOMS_DATA] = rooms
 

--- a/custom_components/ws_core/diagnostics.py
+++ b/custom_components/ws_core/diagnostics.py
@@ -56,7 +56,7 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigE
 
     return {
         "title": entry.title,
-        "version": "2.5.5",
+        "version": "2.6.0",
         "entry_data": _redact_coords(dict(entry.data)),
         "entry_options": _redact_coords(dict(entry.options)),
         "sources": sources,

--- a/custom_components/ws_core/manifest.json
+++ b/custom_components/ws_core/manifest.json
@@ -13,5 +13,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/kmich/ha_ws_core/issues",
   "requirements": [],
-  "version": "2.5.5"
+  "version": "2.6.0"
 }

--- a/custom_components/ws_core/sensor.py
+++ b/custom_components/ws_core/sensor.py
@@ -250,6 +250,7 @@ from .const import (
     UNIT_RAIN_MM,
     UNIT_TEMP_C,
     UNIT_WIND_MS,
+    normalize_indoor_rooms,
 )
 
 
@@ -2460,28 +2461,104 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
     entities: list[SensorEntity] = [WSSensor(coordinator, entry, desc, prefix) for desc in filtered]
 
-    # v2.0.5: dynamic per-room indoor temperature delta sensors
+    # Named indoor rooms (v2.6.0; issue #115): per-room temp-delta, humidity,
+    # CO2 and comfort sensors. Only the metrics a room actually configures are
+    # created. The temp-delta key matches the v2.0.5 scheme so existing
+    # temperature-only rooms keep their entity ids across the upgrade.
     if opts.get(CONF_ENABLE_INDOOR, False):
-        room_temps: list[str] = list(opts.get(CONF_INDOOR_ROOMS) or [])
-        for eid in room_temps:
-            slug = eid.split(".", 1)[-1] if "." in eid else eid
-            state = hass.states.get(eid)
-            friendly = (state.attributes.get("friendly_name") if state else None) or slug.replace("_", " ").title()
-            desc = WSSensorDescription(
-                key=f"indoor_room_delta_{slug}",
-                name=f"Temp Delta - {friendly}",
-                icon="mdi:thermometer-lines",
-                device_class=SensorDeviceClass.TEMPERATURE,
-                native_unit=UNIT_TEMP_C,
-                state_class=SensorStateClass.MEASUREMENT,
-                entity_category=EntityCategory.DIAGNOSTIC,
-                value_fn=lambda d, _eid=eid: (d.get(KEY_INDOOR_ROOMS_DATA) or {}).get(_eid, {}).get("delta_c"),
-                attrs_fn=lambda d, _eid=eid: {
-                    "indoor_temp_c": (d.get(KEY_INDOOR_ROOMS_DATA) or {}).get(_eid, {}).get("temp_c"),
-                    "source_entity": _eid,
-                },
-            )
-            entities.append(WSSensor(coordinator, entry, desc, prefix))
+        for room in normalize_indoor_rooms(opts.get(CONF_INDOOR_ROOMS)):
+            rid = room["id"]
+            name = room["name"]
+            temp_eid = room.get("temp")
+            hum_eid = room.get("humidity")
+            co2_eid = room.get("co2")
+
+            def _room_field(d, _rid=rid, _field=None):
+                return (d.get(KEY_INDOOR_ROOMS_DATA) or {}).get(_rid, {}).get(_field)
+
+            if temp_eid:
+                entities.append(
+                    WSSensor(
+                        coordinator,
+                        entry,
+                        WSSensorDescription(
+                            key=f"indoor_room_delta_{rid}",
+                            name=f"Temp Delta - {name}",
+                            icon="mdi:thermometer-lines",
+                            device_class=SensorDeviceClass.TEMPERATURE,
+                            native_unit=UNIT_TEMP_C,
+                            state_class=SensorStateClass.MEASUREMENT,
+                            entity_category=EntityCategory.DIAGNOSTIC,
+                            value_fn=lambda d, _rid=rid: _room_field(d, _rid, "delta_c"),
+                            attrs_fn=lambda d, _rid=rid, _eid=temp_eid: {
+                                "indoor_temp_c": _room_field(d, _rid, "temp_c"),
+                                "source_entity": _eid,
+                            },
+                        ),
+                        prefix,
+                    )
+                )
+            if hum_eid:
+                entities.append(
+                    WSSensor(
+                        coordinator,
+                        entry,
+                        WSSensorDescription(
+                            key=f"indoor_room_humidity_{rid}",
+                            name=f"Humidity - {name}",
+                            icon="mdi:water-percent",
+                            device_class=SensorDeviceClass.HUMIDITY,
+                            native_unit="%",
+                            state_class=SensorStateClass.MEASUREMENT,
+                            value_fn=lambda d, _rid=rid: _room_field(d, _rid, "humidity_pct"),
+                            attrs_fn=lambda d, _rid=rid, _eid=hum_eid: {
+                                "delta_pct": _room_field(d, _rid, "humidity_delta_pct"),
+                                "source_entity": _eid,
+                            },
+                        ),
+                        prefix,
+                    )
+                )
+            if co2_eid:
+                entities.append(
+                    WSSensor(
+                        coordinator,
+                        entry,
+                        WSSensorDescription(
+                            key=f"indoor_room_co2_{rid}",
+                            name=f"CO₂ - {name}",
+                            icon="mdi:molecule-co2",
+                            device_class=SensorDeviceClass.CO2,
+                            native_unit="ppm",
+                            state_class=SensorStateClass.MEASUREMENT,
+                            value_fn=lambda d, _rid=rid: _room_field(d, _rid, "co2_ppm"),
+                            attrs_fn=lambda d, _rid=rid, _eid=co2_eid: {"source_entity": _eid},
+                        ),
+                        prefix,
+                    )
+                )
+            if temp_eid or hum_eid or co2_eid:
+                entities.append(
+                    WSSensor(
+                        coordinator,
+                        entry,
+                        WSSensorDescription(
+                            key=f"indoor_room_comfort_{rid}",
+                            name=f"Comfort - {name}",
+                            icon="mdi:home-heart",
+                            native_unit=None,
+                            state_class=SensorStateClass.MEASUREMENT,
+                            entity_category=EntityCategory.DIAGNOSTIC,
+                            value_fn=lambda d, _rid=rid: _room_field(d, _rid, "comfort"),
+                            attrs_fn=lambda d, _rid=rid: {
+                                "temp_c": _room_field(d, _rid, "temp_c"),
+                                "humidity_pct": _room_field(d, _rid, "humidity_pct"),
+                                "co2_ppm": _room_field(d, _rid, "co2_ppm"),
+                            },
+                        ),
+                        prefix,
+                    )
+                )
 
     # v1.9.0: dynamic Vigicrues river sensors — one per configured station
     if opts.get(CONF_ENABLE_VIGICRUES, False):

--- a/custom_components/ws_core/strings.json
+++ b/custom_components/ws_core/strings.json
@@ -471,13 +471,40 @@
         }
       },
       "indoor_rooms_opt": {
-        "title": "Indoor Room Sensors",
-        "description": "Select one temperature sensor per room to get a dedicated indoor/outdoor temperature delta sensor for each room.",
+        "title": "Indoor Rooms",
+        "description": "Define named rooms, each with its own temperature, humidity and/or CO2 sensor. Every room gets its own delta and comfort sensors. Choose an action, or select Done to continue.",
+        "menu_options": {
+          "room_add": "Add a room",
+          "room_edit": "Edit a room",
+          "room_remove": "Remove rooms",
+          "room_done": "Done"
+        }
+      },
+      "room_edit": {
+        "title": "Edit Room",
         "data": {
-          "indoor_rooms": "Room temperature sensors"
+          "room": "Room"
+        }
+      },
+      "room_form": {
+        "title": "Room Details",
+        "description": "Name the room and assign any combination of temperature, humidity and CO2 sensors. Leave a sensor blank to skip that metric for this room.",
+        "data": {
+          "name": "Room name",
+          "temp": "Temperature sensor",
+          "humidity": "Humidity sensor",
+          "co2": "CO2 sensor"
         },
         "data_description": {
-          "indoor_rooms": "Each selected sensor creates a separate delta sensor (e.g. WS Temp Delta - Bedroom). Leave empty to use only the single indoor sensor from the previous step."
+          "temp": "Used for the room's indoor/outdoor temperature delta.",
+          "humidity": "Used for the room's indoor/outdoor humidity delta.",
+          "co2": "Used in the room's comfort score."
+        }
+      },
+      "room_remove": {
+        "title": "Remove Rooms",
+        "data": {
+          "rooms": "Rooms to remove"
         }
       },
       "upload_services_opt": {
@@ -620,7 +647,8 @@
       "temp_out_of_range": "Temperature is outside the physically possible range.",
       "invalid_api_key": "Invalid API key or credentials rejected",
       "cannot_connect": "Could not connect to API - check network and try again",
-      "station_not_found": "Weather Underground station ID not found"
+      "station_not_found": "Weather Underground station ID not found",
+      "room_name_required": "Please enter a name for the room."
     }
   },
   "issues": {

--- a/custom_components/ws_core/translations/de.json
+++ b/custom_components/ws_core/translations/de.json
@@ -471,13 +471,40 @@
         }
       },
       "indoor_rooms_opt": {
-        "title": "Innenraum-Temperatursensoren",
-        "description": "Wähle einen Temperatursensor pro Raum aus, um einen eigenen Innen/Außen-Temperaturdifferenz-Sensor für jeden Raum zu erhalten.",
+        "title": "Innenräume",
+        "description": "Definieren Sie benannte Räume mit jeweils eigenem Temperatur-, Feuchte- und/oder CO2-Sensor. Jeder Raum erhält eigene Differenz- und Komfortsensoren. Wählen Sie eine Aktion oder Fertig zum Fortfahren.",
+        "menu_options": {
+          "room_add": "Raum hinzufügen",
+          "room_edit": "Raum bearbeiten",
+          "room_remove": "Räume entfernen",
+          "room_done": "Fertig"
+        }
+      },
+      "room_edit": {
+        "title": "Raum bearbeiten",
         "data": {
-          "indoor_rooms": "Raum-Temperatursensoren"
+          "room": "Raum"
+        }
+      },
+      "room_form": {
+        "title": "Raumdetails",
+        "description": "Benennen Sie den Raum und weisen Sie beliebige Kombinationen von Temperatur-, Feuchte- und CO2-Sensoren zu. Lassen Sie einen Sensor leer, um diese Messgröße für diesen Raum zu überspringen.",
+        "data": {
+          "name": "Raumname",
+          "temp": "Temperatursensor",
+          "humidity": "Feuchtesensor",
+          "co2": "CO2-Sensor"
         },
         "data_description": {
-          "indoor_rooms": "Jeder ausgewählte Sensor erzeugt einen eigenen Differenzsensor (z. B. WS Temp Delta - Schlafzimmer). Leer lassen, um nur den einzelnen Innensensor aus dem vorherigen Schritt zu verwenden."
+          "temp": "Wird für die Innen-/Außentemperaturdifferenz des Raums verwendet.",
+          "humidity": "Wird für die Innen-/Außenfeuchtedifferenz des Raums verwendet.",
+          "co2": "Wird im Komfortscore des Raums verwendet."
+        }
+      },
+      "room_remove": {
+        "title": "Räume entfernen",
+        "data": {
+          "rooms": "Zu entfernende Räume"
         }
       },
       "upload_services_opt": {
@@ -620,7 +647,8 @@
       "temp_out_of_range": "Temperatur liegt außerhalb des physikalisch möglichen Bereichs.",
       "invalid_api_key": "Ungültiger API-Schlüssel oder Zugangsdaten abgelehnt",
       "cannot_connect": "Verbindung zur API konnte nicht hergestellt werden – Netzwerk prüfen und erneut versuchen",
-      "station_not_found": "Weather Underground Stations-ID nicht gefunden"
+      "station_not_found": "Weather Underground Stations-ID nicht gefunden",
+      "room_name_required": "Bitte geben Sie einen Namen für den Raum ein."
     }
   },
   "issues": {

--- a/custom_components/ws_core/translations/en.json
+++ b/custom_components/ws_core/translations/en.json
@@ -471,13 +471,40 @@
         }
       },
       "indoor_rooms_opt": {
-        "title": "Indoor Room Sensors",
-        "description": "Select one temperature sensor per room to get a dedicated indoor/outdoor temperature delta sensor for each room.",
+        "title": "Indoor Rooms",
+        "description": "Define named rooms, each with its own temperature, humidity and/or CO2 sensor. Every room gets its own delta and comfort sensors. Choose an action, or select Done to continue.",
+        "menu_options": {
+          "room_add": "Add a room",
+          "room_edit": "Edit a room",
+          "room_remove": "Remove rooms",
+          "room_done": "Done"
+        }
+      },
+      "room_edit": {
+        "title": "Edit Room",
         "data": {
-          "indoor_rooms": "Room temperature sensors"
+          "room": "Room"
+        }
+      },
+      "room_form": {
+        "title": "Room Details",
+        "description": "Name the room and assign any combination of temperature, humidity and CO2 sensors. Leave a sensor blank to skip that metric for this room.",
+        "data": {
+          "name": "Room name",
+          "temp": "Temperature sensor",
+          "humidity": "Humidity sensor",
+          "co2": "CO2 sensor"
         },
         "data_description": {
-          "indoor_rooms": "Each selected sensor creates a separate delta sensor (e.g. WS Temp Delta - Bedroom). Leave empty to use only the single indoor sensor from the previous step."
+          "temp": "Used for the room's indoor/outdoor temperature delta.",
+          "humidity": "Used for the room's indoor/outdoor humidity delta.",
+          "co2": "Used in the room's comfort score."
+        }
+      },
+      "room_remove": {
+        "title": "Remove Rooms",
+        "data": {
+          "rooms": "Rooms to remove"
         }
       },
       "upload_services_opt": {
@@ -620,7 +647,8 @@
       "temp_out_of_range": "Temperature is outside the physically possible range.",
       "invalid_api_key": "Invalid API key or credentials rejected",
       "cannot_connect": "Could not connect to API - check network and try again",
-      "station_not_found": "Weather Underground station ID not found"
+      "station_not_found": "Weather Underground station ID not found",
+      "room_name_required": "Please enter a name for the room."
     }
   },
   "issues": {

--- a/custom_components/ws_core/translations/es.json
+++ b/custom_components/ws_core/translations/es.json
@@ -468,13 +468,40 @@
         }
       },
       "indoor_rooms_opt": {
-        "title": "Sensores de habitaciones interiores",
-        "description": "Seleccione un sensor de temperatura por habitación para obtener un sensor de diferencia de temperatura interior/exterior dedicado para cada habitación.",
+        "title": "Habitaciones interiores",
+        "description": "Defina habitaciones con nombre, cada una con su propio sensor de temperatura, humedad y/o CO2. Cada habitación obtiene sus propios sensores de diferencia y confort. Elija una acción o seleccione Hecho para continuar.",
+        "menu_options": {
+          "room_add": "Añadir una habitación",
+          "room_edit": "Editar una habitación",
+          "room_remove": "Eliminar habitaciones",
+          "room_done": "Hecho"
+        }
+      },
+      "room_edit": {
+        "title": "Editar habitación",
         "data": {
-          "indoor_rooms": "Sensores de temperatura por habitación"
+          "room": "Habitación"
+        }
+      },
+      "room_form": {
+        "title": "Detalles de la habitación",
+        "description": "Nombre la habitación y asigne cualquier combinación de sensores de temperatura, humedad y CO2. Deje un sensor en blanco para omitir esa medida en esta habitación.",
+        "data": {
+          "name": "Nombre de la habitación",
+          "temp": "Sensor de temperatura",
+          "humidity": "Sensor de humedad",
+          "co2": "Sensor de CO2"
         },
         "data_description": {
-          "indoor_rooms": "Cada sensor seleccionado crea un sensor delta separado (p. ej. WS Temp Delta - Dormitorio). Deje vacío para usar solo el sensor interior único del paso anterior."
+          "temp": "Se usa para la diferencia de temperatura interior/exterior de la habitación.",
+          "humidity": "Se usa para la diferencia de humedad interior/exterior de la habitación.",
+          "co2": "Se usa en la puntuación de confort de la habitación."
+        }
+      },
+      "room_remove": {
+        "title": "Eliminar habitaciones",
+        "data": {
+          "rooms": "Habitaciones a eliminar"
         }
       },
       "upload_services_opt": {
@@ -617,7 +644,8 @@
       "temp_out_of_range": "La temperatura está fuera del rango físicamente posible.",
       "invalid_api_key": "Clave API no válida o credenciales rechazadas",
       "cannot_connect": "No se pudo conectar con la API - verifique la red e inténtelo de nuevo",
-      "station_not_found": "ID de estación de Weather Underground no encontrado"
+      "station_not_found": "ID de estación de Weather Underground no encontrado",
+      "room_name_required": "Introduzca un nombre para la habitación."
     }
   },
   "issues": {

--- a/custom_components/ws_core/translations/fr.json
+++ b/custom_components/ws_core/translations/fr.json
@@ -505,13 +505,40 @@
         }
       },
       "indoor_rooms_opt": {
-        "title": "Capteurs intérieurs des différentes pièces",
-        "description": "Sélectionnez un capteur de température par pièce pour générer un capteur d'écart de température intérieur/extérieur dédié.",
+        "title": "Pièces intérieures",
+        "description": "Définissez des pièces nommées, chacune avec son propre capteur de température, d'humidité et/ou de CO2. Chaque pièce obtient ses propres capteurs d'écart et de confort. Choisissez une action ou sélectionnez Terminé pour continuer.",
+        "menu_options": {
+          "room_add": "Ajouter une pièce",
+          "room_edit": "Modifier une pièce",
+          "room_remove": "Supprimer des pièces",
+          "room_done": "Terminé"
+        }
+      },
+      "room_edit": {
+        "title": "Modifier la pièce",
         "data": {
-          "indoor_rooms": "Capteurs de température par pièce"
+          "room": "Pièce"
+        }
+      },
+      "room_form": {
+        "title": "Détails de la pièce",
+        "description": "Nommez la pièce et attribuez n'importe quelle combinaison de capteurs de température, d'humidité et de CO2. Laissez un capteur vide pour ignorer cette mesure pour cette pièce.",
+        "data": {
+          "name": "Nom de la pièce",
+          "temp": "Capteur de température",
+          "humidity": "Capteur d'humidité",
+          "co2": "Capteur de CO2"
         },
         "data_description": {
-          "indoor_rooms": "Chaque capteur sélectionné génère un capteur d'écart dédié (ex : Écart temp - Chambre). Laissez vide pour utiliser uniquement le capteur intérieur général de l'étape précédente"
+          "temp": "Utilisé pour l'écart de température intérieur/extérieur de la pièce.",
+          "humidity": "Utilisé pour l'écart d'humidité intérieur/extérieur de la pièce.",
+          "co2": "Utilisé dans le score de confort de la pièce."
+        }
+      },
+      "room_remove": {
+        "title": "Supprimer des pièces",
+        "data": {
+          "rooms": "Pièces à supprimer"
         }
       },
       "upload_services_opt": {
@@ -654,7 +681,8 @@
       "temp_out_of_range": "La température dépasse les limites physiques possibles.",
       "invalid_api_key": "Clé API invalide ou identifiants rejetés.",
       "cannot_connect": "Impossible de se connecter à l'API - vérifiez le réseau et réessayez.",
-      "station_not_found": "ID de la station Weather Underground introuvable."
+      "station_not_found": "ID de la station Weather Underground introuvable.",
+      "room_name_required": "Veuillez saisir un nom pour la pièce."
     }
   },
   "issues": {

--- a/custom_components/ws_core/translations/it.json
+++ b/custom_components/ws_core/translations/it.json
@@ -468,13 +468,40 @@
         }
       },
       "indoor_rooms_opt": {
-        "title": "Sensori stanze interne",
-        "description": "Seleziona un sensore di temperatura per stanza per ottenere un sensore dedicato del differenziale di temperatura interno/esterno per ogni stanza.",
+        "title": "Stanze interne",
+        "description": "Definisci stanze con nome, ciascuna con il proprio sensore di temperatura, umidità e/o CO2. Ogni stanza ottiene i propri sensori di differenza e comfort. Scegli un'azione o seleziona Fatto per continuare.",
+        "menu_options": {
+          "room_add": "Aggiungi una stanza",
+          "room_edit": "Modifica una stanza",
+          "room_remove": "Rimuovi stanze",
+          "room_done": "Fatto"
+        }
+      },
+      "room_edit": {
+        "title": "Modifica stanza",
         "data": {
-          "indoor_rooms": "Sensori di temperatura delle stanze"
+          "room": "Stanza"
+        }
+      },
+      "room_form": {
+        "title": "Dettagli stanza",
+        "description": "Assegna un nome alla stanza e qualsiasi combinazione di sensori di temperatura, umidità e CO2. Lascia vuoto un sensore per ignorare quella misura per questa stanza.",
+        "data": {
+          "name": "Nome stanza",
+          "temp": "Sensore di temperatura",
+          "humidity": "Sensore di umidità",
+          "co2": "Sensore di CO2"
         },
         "data_description": {
-          "indoor_rooms": "Ogni sensore selezionato crea un sensore delta separato (es. WS Temp Delta - Camera da letto). Lascia vuoto per usare solo il singolo sensore interno dal passaggio precedente."
+          "temp": "Usato per la differenza di temperatura interno/esterno della stanza.",
+          "humidity": "Usato per la differenza di umidità interno/esterno della stanza.",
+          "co2": "Usato nel punteggio di comfort della stanza."
+        }
+      },
+      "room_remove": {
+        "title": "Rimuovi stanze",
+        "data": {
+          "rooms": "Stanze da rimuovere"
         }
       },
       "upload_services_opt": {
@@ -617,7 +644,8 @@
       "temp_out_of_range": "La temperatura è fuori dall'intervallo fisicamente possibile.",
       "invalid_api_key": "Chiave API non valida o credenziali rifiutate",
       "cannot_connect": "Impossibile connettersi all'API - controlla la rete e riprova",
-      "station_not_found": "ID stazione Weather Underground non trovato"
+      "station_not_found": "ID stazione Weather Underground non trovato",
+      "room_name_required": "Inserisci un nome per la stanza."
     }
   },
   "issues": {

--- a/custom_components/ws_core/translations/nl.json
+++ b/custom_components/ws_core/translations/nl.json
@@ -468,13 +468,40 @@
         }
       },
       "indoor_rooms_opt": {
-        "title": "Binnenruimte-sensoren",
-        "description": "Selecteer per ruimte een temperatuursensor om een aparte binnen/buiten-temperatuurverschilsensor voor elke ruimte te krijgen.",
+        "title": "Binnenruimtes",
+        "description": "Definieer benoemde ruimtes, elk met een eigen temperatuur-, vochtigheids- en/of CO2-sensor. Elke ruimte krijgt eigen verschil- en comfortsensoren. Kies een actie of selecteer Klaar om door te gaan.",
+        "menu_options": {
+          "room_add": "Ruimte toevoegen",
+          "room_edit": "Ruimte bewerken",
+          "room_remove": "Ruimtes verwijderen",
+          "room_done": "Klaar"
+        }
+      },
+      "room_edit": {
+        "title": "Ruimte bewerken",
         "data": {
-          "indoor_rooms": "Ruimtetemperatuursensoren"
+          "room": "Ruimte"
+        }
+      },
+      "room_form": {
+        "title": "Ruimtedetails",
+        "description": "Geef de ruimte een naam en wijs een willekeurige combinatie van temperatuur-, vochtigheids- en CO2-sensoren toe. Laat een sensor leeg om die meting voor deze ruimte over te slaan.",
+        "data": {
+          "name": "Ruimtenaam",
+          "temp": "Temperatuursensor",
+          "humidity": "Vochtigheidssensor",
+          "co2": "CO2-sensor"
         },
         "data_description": {
-          "indoor_rooms": "Voor elke geselecteerde sensor wordt een aparte verschilsensor aangemaakt (bijv. WS Temp Delta - Slaapkamer). Laat leeg om alleen de enkele binnensensor van de vorige stap te gebruiken."
+          "temp": "Gebruikt voor het binnen/buiten-temperatuurverschil van de ruimte.",
+          "humidity": "Gebruikt voor het binnen/buiten-vochtigheidsverschil van de ruimte.",
+          "co2": "Gebruikt in de comfortscore van de ruimte."
+        }
+      },
+      "room_remove": {
+        "title": "Ruimtes verwijderen",
+        "data": {
+          "rooms": "Te verwijderen ruimtes"
         }
       },
       "upload_services_opt": {
@@ -617,7 +644,8 @@
       "temp_out_of_range": "Temperatuur ligt buiten het fysiek mogelijke bereik.",
       "invalid_api_key": "Ongeldige API-sleutel of inloggegevens geweigerd",
       "cannot_connect": "Kan geen verbinding maken met API - controleer het netwerk en probeer opnieuw",
-      "station_not_found": "Weather Underground station-ID niet gevonden"
+      "station_not_found": "Weather Underground station-ID niet gevonden",
+      "room_name_required": "Voer een naam in voor de ruimte."
     }
   },
   "issues": {

--- a/custom_components/ws_core/translations/pl.json
+++ b/custom_components/ws_core/translations/pl.json
@@ -471,13 +471,40 @@
         }
       },
       "indoor_rooms_opt": {
-        "title": "Czujniki pokojowe wewnętrzne",
-        "description": "Wybierz jeden czujnik temperatury na pokój, aby uzyskać dedykowany czujnik różnicy temperatury wewnątrz/na zewnątrz dla każdego pokoju.",
+        "title": "Pomieszczenia wewnętrzne",
+        "description": "Zdefiniuj nazwane pomieszczenia, każde z własnym czujnikiem temperatury, wilgotności i/lub CO2. Każde pomieszczenie otrzymuje własne czujniki różnicy i komfortu. Wybierz akcję lub wybierz Gotowe, aby kontynuować.",
+        "menu_options": {
+          "room_add": "Dodaj pomieszczenie",
+          "room_edit": "Edytuj pomieszczenie",
+          "room_remove": "Usuń pomieszczenia",
+          "room_done": "Gotowe"
+        }
+      },
+      "room_edit": {
+        "title": "Edytuj pomieszczenie",
         "data": {
-          "indoor_rooms": "Czujniki temperatury pokojowej"
+          "room": "Pomieszczenie"
+        }
+      },
+      "room_form": {
+        "title": "Szczegóły pomieszczenia",
+        "description": "Nazwij pomieszczenie i przypisz dowolną kombinację czujników temperatury, wilgotności i CO2. Pozostaw czujnik pusty, aby pominąć ten pomiar dla tego pomieszczenia.",
+        "data": {
+          "name": "Nazwa pomieszczenia",
+          "temp": "Czujnik temperatury",
+          "humidity": "Czujnik wilgotności",
+          "co2": "Czujnik CO2"
         },
         "data_description": {
-          "indoor_rooms": "Każdy wybrany czujnik tworzy osobny czujnik różnicy (np. WS Temp Delta - Sypialnia). Pozostaw puste, aby używać tylko pojedynczego czujnika wewnętrznego z poprzedniego kroku."
+          "temp": "Używany do różnicy temperatury wewnątrz/na zewnątrz pomieszczenia.",
+          "humidity": "Używany do różnicy wilgotności wewnątrz/na zewnątrz pomieszczenia.",
+          "co2": "Używany w ocenie komfortu pomieszczenia."
+        }
+      },
+      "room_remove": {
+        "title": "Usuń pomieszczenia",
+        "data": {
+          "rooms": "Pomieszczenia do usunięcia"
         }
       },
       "upload_services_opt": {
@@ -620,7 +647,8 @@
       "temp_out_of_range": "Temperatura jest poza fizycznie możliwym zakresem.",
       "invalid_api_key": "Nieprawidłowy klucz API lub odrzucone dane logowania",
       "cannot_connect": "Nie można połączyć się z API - sprawdź sieć i spróbuj ponownie",
-      "station_not_found": "Nie znaleziono identyfikatora stacji Weather Underground"
+      "station_not_found": "Nie znaleziono identyfikatora stacji Weather Underground",
+      "room_name_required": "Wprowadź nazwę pomieszczenia."
     }
   },
   "issues": {

--- a/custom_components/ws_core/translations/pt.json
+++ b/custom_components/ws_core/translations/pt.json
@@ -468,13 +468,40 @@
         }
       },
       "indoor_rooms_opt": {
-        "title": "Sensores de divisões interiores",
-        "description": "Selecione um sensor de temperatura por divisão para obter um sensor dedicado de diferença de temperatura interior/exterior para cada divisão.",
+        "title": "Divisões interiores",
+        "description": "Defina divisões nomeadas, cada uma com o seu próprio sensor de temperatura, humidade e/ou CO2. Cada divisão obtém os seus próprios sensores de diferença e conforto. Escolha uma ação ou selecione Concluído para continuar.",
+        "menu_options": {
+          "room_add": "Adicionar uma divisão",
+          "room_edit": "Editar uma divisão",
+          "room_remove": "Remover divisões",
+          "room_done": "Concluído"
+        }
+      },
+      "room_edit": {
+        "title": "Editar divisão",
         "data": {
-          "indoor_rooms": "Sensores de temperatura por divisão"
+          "room": "Divisão"
+        }
+      },
+      "room_form": {
+        "title": "Detalhes da divisão",
+        "description": "Dê um nome à divisão e atribua qualquer combinação de sensores de temperatura, humidade e CO2. Deixe um sensor em branco para ignorar essa medida nesta divisão.",
+        "data": {
+          "name": "Nome da divisão",
+          "temp": "Sensor de temperatura",
+          "humidity": "Sensor de humidade",
+          "co2": "Sensor de CO2"
         },
         "data_description": {
-          "indoor_rooms": "Cada sensor selecionado cria um sensor de diferença separado (ex. WS Diferença Temp - Quarto). Deixe em branco para usar apenas o sensor interior único do passo anterior."
+          "temp": "Usado para a diferença de temperatura interior/exterior da divisão.",
+          "humidity": "Usado para a diferença de humidade interior/exterior da divisão.",
+          "co2": "Usado na pontuação de conforto da divisão."
+        }
+      },
+      "room_remove": {
+        "title": "Remover divisões",
+        "data": {
+          "rooms": "Divisões a remover"
         }
       },
       "upload_services_opt": {
@@ -617,7 +644,8 @@
       "temp_out_of_range": "A temperatura está fora do intervalo fisicamente possível.",
       "invalid_api_key": "Chave API inválida ou credenciais rejeitadas",
       "cannot_connect": "Não foi possível ligar à API - verifique a rede e tente novamente",
-      "station_not_found": "ID da estação Weather Underground não encontrado"
+      "station_not_found": "ID da estação Weather Underground não encontrado",
+      "room_name_required": "Introduza um nome para a divisão."
     }
   },
   "issues": {

--- a/docs/sensors.md
+++ b/docs/sensors.md
@@ -175,7 +175,12 @@ Supports WH57, AS3935, and Blitzortung. Blitzortung is auto-discovered if instal
 | `sensor.ws_indoor_temp_delta` | Indoor temperature minus outdoor temperature |
 | `sensor.ws_indoor_humidity_delta` | Indoor humidity minus outdoor humidity |
 | `sensor.ws_indoor_comfort` | 0-100 composite indoor comfort score |
-| `sensor.ws_indoor_room_delta_<room>` | Per-room temperature delta (one per configured room) |
+| `sensor.ws_indoor_room_delta_<room>` | Per-room indoor/outdoor temperature delta (one per room with a temperature sensor) |
+| `sensor.ws_indoor_room_humidity_<room>` | Per-room indoor humidity, with outdoor delta attribute (rooms with a humidity sensor) |
+| `sensor.ws_indoor_room_co2_<room>` | Per-room CO₂ in ppm (rooms with a CO₂ sensor) |
+| `sensor.ws_indoor_room_comfort_<room>` | Per-room 0-100 composite comfort score (any room with at least one sensor) |
+
+Indoor rooms are configured under **Configure → Indoor Rooms**, where each room is given a name and any combination of temperature, humidity and CO₂ sensors.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha_ws_core"
-version = "2.5.5"
+version = "2.6.0"
 description = "Weather Station Core - Home Assistant integration for personal weather stations"
 requires-python = ">=3.12"
 

--- a/tests/test_indoor_rooms.py
+++ b/tests/test_indoor_rooms.py
@@ -1,0 +1,109 @@
+"""Tests for named multi-room indoor monitoring (issue #115, v2.6.0).
+
+Exercises WSStationCoordinator._compute_indoor directly with a minimal
+hand-built coordinator so we don't need a full HA environment.
+"""
+
+import os
+import sys
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from custom_components.ws_core.const import (
+    KEY_INDOOR_ROOMS_DATA,
+    KEY_NORM_HUMIDITY,
+    KEY_NORM_TEMP_C,
+)
+from custom_components.ws_core.coordinator import WSStationCoordinator
+
+
+def _state(val, unit=""):
+    m = MagicMock()
+    m.state = str(val)
+    m.attributes = {"unit_of_measurement": unit}
+    m.last_updated = datetime.now(UTC)
+    return m
+
+
+def _build_coord(states, rooms):
+    hass = MagicMock()
+    hass.states.get = lambda eid: states.get(eid)
+    with patch.object(WSStationCoordinator, "__init__", lambda self, *a, **kw: None):
+        coord = WSStationCoordinator.__new__(WSStationCoordinator)
+    coord.hass = hass
+    coord.indoor_enabled = True
+    coord._indoor_rooms = rooms
+    coord._indoor_temp_prev = None
+    coord._indoor_hum_prev = None
+    # No main indoor group sensors configured for these tests.
+    coord.sources = {}
+    return coord
+
+
+class TestIndoorRooms:
+    def test_full_room_temp_humidity_co2_and_comfort(self):
+        states = {
+            "sensor.bed_t": _state(21.0, "°C"),
+            "sensor.bed_h": _state(45.0, "%"),
+            "sensor.bed_c": _state(800, "ppm"),
+        }
+        rooms = [{"id": "bedroom", "name": "Bedroom", "temp": "sensor.bed_t",
+                  "humidity": "sensor.bed_h", "co2": "sensor.bed_c"}]
+        coord = _build_coord(states, rooms)
+
+        data = {KEY_NORM_TEMP_C: 10.0, KEY_NORM_HUMIDITY: 60.0}
+        coord._compute_indoor(data)
+
+        room = data[KEY_INDOOR_ROOMS_DATA]["bedroom"]
+        assert room["name"] == "Bedroom"
+        assert room["temp_c"] == 21.0
+        assert room["delta_c"] == 11.0  # 21 indoor - 10 outdoor
+        assert room["humidity_pct"] == 45.0
+        assert room["humidity_delta_pct"] == -15.0  # 45 - 60
+        assert room["co2_ppm"] == 800
+        assert room["comfort"] == 100  # all values in comfortable bands
+
+    def test_co2_penalty_lowers_comfort(self):
+        states = {"sensor.t": _state(21.0, "°C"), "sensor.c": _state(1800, "ppm")}
+        rooms = [{"id": "office", "name": "Office", "temp": "sensor.t",
+                  "humidity": None, "co2": "sensor.c"}]
+        coord = _build_coord(states, rooms)
+        data = {KEY_NORM_TEMP_C: 18.0}
+        coord._compute_indoor(data)
+        room = data[KEY_INDOOR_ROOMS_DATA]["office"]
+        # CO2 >1500 -> -25; temp in band -> no penalty.
+        assert room["comfort"] == 75
+        assert "humidity_pct" not in room  # no humidity sensor assigned
+
+    def test_temperature_only_room_has_no_co2_or_humidity_fields(self):
+        states = {"sensor.t": _state(19.5, "°C")}
+        rooms = [{"id": "loft", "name": "Loft", "temp": "sensor.t",
+                  "humidity": None, "co2": None}]
+        coord = _build_coord(states, rooms)
+        data = {KEY_NORM_TEMP_C: 5.0}
+        coord._compute_indoor(data)
+        room = data[KEY_INDOOR_ROOMS_DATA]["loft"]
+        assert room["temp_c"] == 19.5
+        assert room["delta_c"] == 14.5
+        assert "co2_ppm" not in room and "humidity_pct" not in room
+        assert room["comfort"] == 100
+
+    def test_unavailable_sensor_is_skipped(self):
+        states = {"sensor.t": _state("unavailable", "°C")}
+        rooms = [{"id": "garage", "name": "Garage", "temp": "sensor.t",
+                  "humidity": None, "co2": None}]
+        coord = _build_coord(states, rooms)
+        data = {KEY_NORM_TEMP_C: 5.0}
+        coord._compute_indoor(data)
+        # Room dict still present (carries name) but no readings.
+        room = data[KEY_INDOOR_ROOMS_DATA]["garage"]
+        assert "temp_c" not in room
+        assert "comfort" not in room
+
+    def test_no_rooms_leaves_key_unset(self):
+        coord = _build_coord({}, [])
+        data = {KEY_NORM_TEMP_C: 10.0}
+        coord._compute_indoor(data)
+        assert KEY_INDOOR_ROOMS_DATA not in data

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -87,3 +87,50 @@ class TestMigration:
             "australia",
             "custom",
         }
+
+
+class TestIndoorRoomsMigration:
+    """v3 -> v4 (v2.6.0): legacy list[str] indoor rooms -> named-room dicts."""
+
+    def test_legacy_entity_id_list_is_upconverted(self):
+        _, cap = _run_migration(
+            3,
+            {"prefix": "ws"},
+            {"indoor_rooms": ["sensor.bedroom_temp", "sensor.office_temp"]},
+        )
+        assert cap["version"] == CONFIG_VERSION
+        rooms = cap["options"]["indoor_rooms"]
+        assert isinstance(rooms, list) and len(rooms) == 2
+        first = rooms[0]
+        assert first["temp"] == "sensor.bedroom_temp"
+        assert first["humidity"] is None and first["co2"] is None
+        assert first["id"] and first["name"]
+        # Name derived from the entity slug, title-cased.
+        assert first["name"] == "Bedroom Temp"
+
+    def test_already_dict_shape_is_preserved(self):
+        room = {
+            "id": "bedroom",
+            "name": "Bedroom",
+            "temp": "sensor.bt",
+            "humidity": "sensor.bh",
+            "co2": None,
+        }
+        _, cap = _run_migration(3, {"prefix": "ws"}, {"indoor_rooms": [room]})
+        rooms = cap["options"]["indoor_rooms"]
+        assert rooms[0]["id"] == "bedroom"
+        assert rooms[0]["humidity"] == "sensor.bh"
+
+    def test_no_indoor_rooms_key_is_noop(self):
+        _, cap = _run_migration(3, {"prefix": "ws"}, {})
+        assert "indoor_rooms" not in cap["options"]
+        assert cap["version"] == CONFIG_VERSION
+
+    def test_duplicate_ids_are_deduplicated(self):
+        _, cap = _run_migration(
+            3,
+            {"prefix": "ws"},
+            {"indoor_rooms": ["sensor.temp", "sensor.temp"]},
+        )
+        rooms = cap["options"]["indoor_rooms"]
+        assert rooms[0]["id"] != rooms[1]["id"]


### PR DESCRIPTION
## Description

Implements full named multi-room indoor monitoring (issue #115). The single-room indoor feature becomes any number of **named rooms**, each with its own temperature, humidity and/or CO2 sensor. Each room gets dedicated sensors, created only for the metrics actually assigned:

- `sensor.ws_indoor_room_delta_<room>` - indoor/outdoor temperature delta
- `sensor.ws_indoor_room_humidity_<room>` - humidity (outdoor delta in attributes)
- `sensor.ws_indoor_room_co2_<room>` - CO2 (ppm)
- `sensor.ws_indoor_room_comfort_<room>` - 0-100 composite comfort score

Rooms are managed from a new **add / edit / remove** screen in the options flow (Configure → Indoor Rooms).

## Design notes

- **Data model:** `CONF_INDOOR_ROOMS` moves from `list[str]` (temp entity_ids) to `list[dict]` `{id, name, temp, humidity, co2}`. A stable `id` backs each room's entity unique_ids, so renaming a room does not churn entities.
- **Migration:** `CONFIG_VERSION` 3 → 4. `async_migrate_entry` upconverts legacy temperature-only rooms; the temp-delta sensor key is unchanged so **existing entities survive the upgrade**.
- **Shared scoring:** comfort logic extracted to `algorithms.indoor_comfort_score()`, used by both the main indoor group and per-room comfort.

## Related Issue

Closes #115

## How Has This Been Tested?

- `pytest -q` → **268 passed** (added `tests/test_indoor_rooms.py` for per-room compute + extended `tests/test_migration.py` for v3 → v4)
- `ruff check` and `ruff format --check` clean
- Version consistency (manifest / pyproject / diagnostics) at 2.6.0
- All 8 translation bundles validated as parseable JSON

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change

## Checklist:

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly (docs/sensors.md)
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have updated CHANGELOG.md with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)