### PR TITLE
fix(translations): add named indoor rooms to initial setup + fix missing en strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Weather Station Core are documented here.
 
+## [2.6.1] - 2026-07-01
+
+### Added
+
+- **Named indoor rooms during initial setup (PR #120):** the add/edit/remove indoor rooms screen introduced in 2.6.0 for the options flow is now also available during first-time setup (Configure Weather Station -> Features -> Indoor Rooms), so multi-room monitoring can be configured without a follow-up trip to Options. Thanks @Benjamin45590.
+
+### Fixed
+
+- **Indoor Rooms step skipped in Options flow when Vigicrues was also enabled:** finishing the Vigicrues station step used to jump straight to Upload Services, bypassing the Indoor Rooms step entirely whenever both features were enabled. Options-flow navigation now correctly chains through every enabled feature step in order.
+- **Missing English translations for the new indoor-room setup steps:** PR #120 added the new config-flow steps but only PR #121 supplied translations (French only). Added the corresponding `strings.json` / `en.json` entries so the flow renders correctly in English.
+
 ## [2.6.0] - 2026-06-30
 
 ### Added

--- a/custom_components/ws_core/config_flow.py
+++ b/custom_components/ws_core/config_flow.py
@@ -1058,6 +1058,8 @@ class WSStationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return await self.async_step_solar_forecast()
             if self._data[CONF_ENABLE_VIGICRUES]:
                 return await self.async_step_vigicrues_station()
+            if self._data[CONF_ENABLE_INDOOR]:
+                return await self.async_step_indoor_rooms()
             if self._data[CONF_ENABLE_WEATHERCLOUD]:
                 return await self.async_step_weathercloud()
             if self._data[CONF_ENABLE_PWSWEATHER]:
@@ -1161,6 +1163,8 @@ class WSStationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return await self.async_step_solar_forecast()
             if self._data.get(CONF_ENABLE_VIGICRUES):
                 return await self.async_step_vigicrues_station()
+            if self._data.get(CONF_ENABLE_INDOOR):
+                return await self.async_step_indoor_rooms()
             return await self._next_v2_step()
 
         default_lat = getattr(self.hass.config, "latitude", 0.0) or 0.0
@@ -1226,6 +1230,8 @@ class WSStationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     return await self.async_step_solar_forecast()
                 if self._data.get(CONF_ENABLE_VIGICRUES):
                     return await self.async_step_vigicrues_station()
+                if self._data.get(CONF_ENABLE_INDOOR):
+                    return await self.async_step_indoor_rooms()
                 return await self._next_v2_step()
 
         existing_station = self._data.get(CONF_WU_STATION_ID, "")
@@ -1266,6 +1272,8 @@ class WSStationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return await self.async_step_solar_forecast()
             if self._data.get(CONF_ENABLE_VIGICRUES):
                 return await self.async_step_vigicrues_station()
+            if self._data.get(CONF_ENABLE_INDOOR):
+                return await self.async_step_indoor_rooms()
             return await self._next_v2_step()
 
         return self._show_step(
@@ -1297,6 +1305,8 @@ class WSStationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return await self.async_step_solar_forecast()
             if self._data.get(CONF_ENABLE_VIGICRUES):
                 return await self.async_step_vigicrues_station()
+            if self._data.get(CONF_ENABLE_INDOOR):
+                return await self.async_step_indoor_rooms()
             return await self._next_v2_step()
 
         return self._show_step(
@@ -1323,6 +1333,8 @@ class WSStationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             if self._data.get(CONF_ENABLE_VIGICRUES):
                 return await self.async_step_vigicrues_station()
+            if self._data.get(CONF_ENABLE_INDOOR):
+                return await self.async_step_indoor_rooms()
             return await self._next_v2_step()
 
         return self._show_step(
@@ -1378,6 +1390,8 @@ class WSStationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         break
             # Empty list means auto-detect nearest station
             self._data[CONF_VIGICRUES_STATIONS] = stations
+            if self._data.get(CONF_ENABLE_INDOOR):
+                return await self.async_step_indoor_rooms()
             return await self._next_v2_step()
 
         lat = self._data.get(CONF_FORECAST_LAT) or getattr(self.hass.config, "latitude", 0.0) or 0.0
@@ -1405,6 +1419,114 @@ class WSStationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                             multiple=True,
                         )
                     ),
+                }
+            ),
+            last_step=False,
+        )
+
+    # ------------------------------------------------------------------
+    # Named indoor rooms (initial setup) - add / edit / remove hub
+    # Mirrors the Options flow's indoor_rooms_opt hub so rooms can be
+    # configured during the first install, not just from Options afterward.
+    # ------------------------------------------------------------------
+    def _rooms_working_copy(self) -> list[dict]:
+        """Return (initializing if needed) the in-progress room list."""
+        if CONF_INDOOR_ROOMS not in self._data:
+            self._data[CONF_INDOOR_ROOMS] = normalize_indoor_rooms(self._data.get(CONF_INDOOR_ROOMS, []))
+        return self._data[CONF_INDOOR_ROOMS]
+
+    def _room_form_schema(self, src: dict | None) -> vol.Schema:
+        src = src or {}
+        sensor_sel = selector.EntitySelector(selector.EntitySelectorConfig(domain="sensor"))
+        schema: dict[Any, Any] = {
+            vol.Required("name", default=src.get("name", "")): selector.TextSelector(),
+        }
+        for field in ("temp", "humidity", "co2"):
+            cur = src.get(field)
+            key = vol.Optional(field, default=cur) if cur else vol.Optional(field)
+            schema[key] = sensor_sel
+        return vol.Schema(schema)
+
+    async def async_step_indoor_rooms(self, user_input: dict[str, Any] | None = None):
+        """Hub menu for managing named indoor rooms."""
+        rooms = self._rooms_working_copy()
+        menu_options = ["room_add"]
+        if rooms:
+            menu_options += ["room_edit", "room_remove"]
+        menu_options.append("room_done")
+        return self.async_show_menu(step_id="indoor_rooms", menu_options=menu_options)
+
+    async def async_step_room_done(self, user_input: dict[str, Any] | None = None):
+        return await self._next_v2_step()
+
+    async def async_step_room_add(self, user_input: dict[str, Any] | None = None):
+        self._edit_rid: str | None = None
+        return await self.async_step_room_form()
+
+    async def async_step_room_edit(self, user_input: dict[str, Any] | None = None):
+        rooms = self._rooms_working_copy()
+        if user_input is not None:
+            self._edit_rid = user_input["room"]
+            return await self.async_step_room_form()
+        options = [{"value": r["id"], "label": r["name"]} for r in rooms]
+        return self.async_show_form(
+            step_id="room_edit",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("room"): selector.SelectSelector(
+                        selector.SelectSelectorConfig(options=options, mode=selector.SelectSelectorMode.DROPDOWN)
+                    )
+                }
+            ),
+            last_step=False,
+        )
+
+    async def async_step_room_form(self, user_input: dict[str, Any] | None = None):
+        rooms = self._rooms_working_copy()
+        editing = next((r for r in rooms if r["id"] == self._edit_rid), None) if self._edit_rid else None
+        if user_input is not None:
+            name = (user_input.get("name") or "").strip()
+            if not name:
+                return self.async_show_form(
+                    step_id="room_form",
+                    data_schema=self._room_form_schema({**(editing or {}), **user_input}),
+                    errors={"name": "room_name_required"},
+                    last_step=False,
+                )
+            room = {
+                "id": editing["id"] if editing else uuid.uuid4().hex[:8],
+                "name": name,
+                "temp": user_input.get("temp") or None,
+                "humidity": user_input.get("humidity") or None,
+                "co2": user_input.get("co2") or None,
+            }
+            if editing:
+                self._data[CONF_INDOOR_ROOMS] = [room if r["id"] == editing["id"] else r for r in rooms]
+            else:
+                self._data[CONF_INDOOR_ROOMS] = [*rooms, room]
+            return await self.async_step_indoor_rooms()
+        return self.async_show_form(
+            step_id="room_form",
+            data_schema=self._room_form_schema(editing),
+            last_step=False,
+        )
+
+    async def async_step_room_remove(self, user_input: dict[str, Any] | None = None):
+        rooms = self._rooms_working_copy()
+        if user_input is not None:
+            to_remove = set(user_input.get("rooms") or [])
+            self._data[CONF_INDOOR_ROOMS] = [r for r in rooms if r["id"] not in to_remove]
+            return await self.async_step_indoor_rooms()
+        options = [{"value": r["id"], "label": r["name"]} for r in rooms]
+        return self.async_show_form(
+            step_id="room_remove",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional("rooms", default=[]): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=options, multiple=True, mode=selector.SelectSelectorMode.LIST
+                        )
+                    )
                 }
             ),
             last_step=False,
@@ -2361,7 +2483,7 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
         return self.async_show_menu(step_id="indoor_rooms_opt", menu_options=menu_options)
 
     async def async_step_room_done(self, user_input: dict[str, Any] | None = None):
-        return await self.async_step_upload_services_opt()
+        return await self._finish_or_next("indoor_rooms_opt")
 
     async def async_step_room_add(self, user_input: dict[str, Any] | None = None):
         self._edit_rid: str | None = None
@@ -2795,6 +2917,7 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
             (CONF_ENABLE_POLLEN, "pollen_opt"),
             (CONF_ENABLE_SOLAR_FORECAST, "solar_forecast_opt"),
             (CONF_ENABLE_VIGICRUES, "vigicrues_station_opt"),
+            (CONF_ENABLE_INDOOR, "indoor_rooms_opt"),
         ]
         past = False
         for conf_key, step_name in order:
@@ -2972,7 +3095,7 @@ class WSStationOptionsFlowHandler(config_entries.OptionsFlow):
                         break
             # Empty list means auto-detect nearest station
             self._opt[CONF_VIGICRUES_STATIONS] = stations
-            return await self.async_step_upload_services_opt()
+            return await self._finish_or_next("vigicrues_station_opt")
 
         lat = (
             self._opt.get(CONF_FORECAST_LAT)

--- a/custom_components/ws_core/diagnostics.py
+++ b/custom_components/ws_core/diagnostics.py
@@ -56,7 +56,7 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigE
 
     return {
         "title": entry.title,
-        "version": "2.6.0",
+        "version": "2.6.1",
         "entry_data": _redact_coords(dict(entry.data)),
         "entry_options": _redact_coords(dict(entry.options)),
         "sources": sources,

--- a/custom_components/ws_core/manifest.json
+++ b/custom_components/ws_core/manifest.json
@@ -13,5 +13,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/kmich/ha_ws_core/issues",
   "requirements": [],
-  "version": "2.6.0"
+  "version": "2.6.1"
 }

--- a/custom_components/ws_core/strings.json
+++ b/custom_components/ws_core/strings.json
@@ -280,6 +280,43 @@
           "vigicrues_stations": "Select one or more stations. Leave empty to auto-detect the nearest station."
         }
       },
+      "indoor_rooms": {
+        "title": "Indoor Rooms",
+        "description": "Define named rooms, each with its own temperature, humidity and/or CO2 sensor. Every room gets its own delta and comfort sensors. Choose an action, or select Done to continue.",
+        "menu_options": {
+          "room_add": "Add a room",
+          "room_edit": "Edit a room",
+          "room_remove": "Remove rooms",
+          "room_done": "Done"
+        }
+      },
+      "room_edit": {
+        "title": "Edit Room",
+        "data": {
+          "room": "Room"
+        }
+      },
+      "room_form": {
+        "title": "Room Details",
+        "description": "Name the room and assign any combination of temperature, humidity and CO2 sensors. Leave a sensor blank to skip that metric for this room.",
+        "data": {
+          "name": "Room name",
+          "temp": "Temperature sensor",
+          "humidity": "Humidity sensor",
+          "co2": "CO2 sensor"
+        },
+        "data_description": {
+          "temp": "Used for the room's indoor/outdoor temperature delta.",
+          "humidity": "Used for the room's indoor/outdoor humidity delta.",
+          "co2": "Used in the room's comfort score."
+        }
+      },
+      "room_remove": {
+        "title": "Remove Rooms",
+        "data": {
+          "rooms": "Rooms to remove"
+        }
+      },
       "cwop": {
         "title": "CWOP (APRS) Upload",
         "description": "{info}",
@@ -303,7 +340,8 @@
       "temp_out_of_range": "Temperature is outside the physically possible range.",
       "invalid_api_key": "Invalid API key or credentials rejected",
       "cannot_connect": "Could not connect to API - check network and try again",
-      "station_not_found": "Weather Underground station ID not found"
+      "station_not_found": "Weather Underground station ID not found",
+      "room_name_required": "Please enter a name for the room."
     },
     "create_entry": {
       "default": "Setup complete! Your local forecasts and intelligent weather sensors are now generating.\n\n**Next steps:**\n1. Install the Enhanced Dashboard (from the GitHub repository dashboards/ folder)\n2. Set up a Rain Warning Automation (from the blueprints/ folder)"

--- a/custom_components/ws_core/translations/en.json
+++ b/custom_components/ws_core/translations/en.json
@@ -280,6 +280,43 @@
           "vigicrues_stations": "Select one or more stations. Leave empty to auto-detect the nearest station."
         }
       },
+      "indoor_rooms": {
+        "title": "Indoor Rooms",
+        "description": "Define named rooms, each with its own temperature, humidity and/or CO2 sensor. Every room gets its own delta and comfort sensors. Choose an action, or select Done to continue.",
+        "menu_options": {
+          "room_add": "Add a room",
+          "room_edit": "Edit a room",
+          "room_remove": "Remove rooms",
+          "room_done": "Done"
+        }
+      },
+      "room_edit": {
+        "title": "Edit Room",
+        "data": {
+          "room": "Room"
+        }
+      },
+      "room_form": {
+        "title": "Room Details",
+        "description": "Name the room and assign any combination of temperature, humidity and CO2 sensors. Leave a sensor blank to skip that metric for this room.",
+        "data": {
+          "name": "Room name",
+          "temp": "Temperature sensor",
+          "humidity": "Humidity sensor",
+          "co2": "CO2 sensor"
+        },
+        "data_description": {
+          "temp": "Used for the room's indoor/outdoor temperature delta.",
+          "humidity": "Used for the room's indoor/outdoor humidity delta.",
+          "co2": "Used in the room's comfort score."
+        }
+      },
+      "room_remove": {
+        "title": "Remove Rooms",
+        "data": {
+          "rooms": "Rooms to remove"
+        }
+      },
       "cwop": {
         "title": "CWOP (APRS) Upload",
         "description": "{info}",
@@ -303,7 +340,8 @@
       "temp_out_of_range": "Temperature is outside the physically possible range.",
       "invalid_api_key": "Invalid API key or credentials rejected",
       "cannot_connect": "Could not connect to API - check network and try again",
-      "station_not_found": "Weather Underground station ID not found"
+      "station_not_found": "Weather Underground station ID not found",
+      "room_name_required": "Please enter a name for the room."
     },
     "create_entry": {
       "default": "Setup complete! Your local forecasts and intelligent weather sensors are now generating.\n\n**Next steps:**\n1. Install the Enhanced Dashboard (from the GitHub repository dashboards/ folder)\n2. Set up a Rain Warning Automation (from the blueprints/ folder)"

--- a/custom_components/ws_core/translations/fr.json
+++ b/custom_components/ws_core/translations/fr.json
@@ -301,6 +301,43 @@
           "vigicrues_stations": "Sélectionnez une ou plusieurs stations. Laissez vide pour détecter automatiquement la station la plus proche."
         }
       },
+      "indoor_rooms": {
+        "title": "Pièces intérieures",
+        "description": "Définissez des pièces nommées, chacune avec son propre capteur de température, d'humidité et/ou de CO2. Chaque pièce obtient ses propres capteurs d'écart et de confort. Choisissez une action ou sélectionnez Terminé pour continuer.",
+        "menu_options": {
+          "room_add": "Ajouter une pièce",
+          "room_edit": "Modifier une pièce",
+          "room_remove": "Supprimer des pièces",
+          "room_done": "Terminé"
+        }
+      },
+      "room_edit": {
+        "title": "Modifier la pièce",
+        "data": {
+          "room": "Pièce"
+        }
+      },
+      "room_form": {
+        "title": "Détails de la pièce",
+        "description": "Nommez la pièce et attribuez n'importe quelle combinaison de capteurs de température, d'humidité et de CO2. Laissez un capteur vide pour ignorer cette mesure pour cette pièce.",
+        "data": {
+          "name": "Nom de la pièce",
+          "temp": "Capteur de température",
+          "humidity": "Capteur d'humidité",
+          "co2": "Capteur de CO2"
+        },
+        "data_description": {
+          "temp": "Utilisé pour l'écart de température intérieur/extérieur de la pièce.",
+          "humidity": "Utilisé pour l'écart d'humidité intérieur/extérieur de la pièce.",
+          "co2": "Utilisé dans le score de confort de la pièce."
+        }
+      },
+      "room_remove": {
+        "title": "Supprimer des pièces",
+        "data": {
+          "rooms": "Pièces à supprimer"
+        }
+      },
       "cwop": {
         "title": "Envoi vers CWOP (APRS)",
         "description": "{info}",
@@ -324,7 +361,8 @@
       "temp_out_of_range": "La température dépasse les limites physiques possibles.",
       "invalid_api_key": "Clé API invalide ou identifiants rejetés.",
       "cannot_connect": "Impossible de se connecter à l'API - vérifiez le réseau et réessayez.",
-      "station_not_found": "ID de la station Weather Underground introuvable."
+      "station_not_found": "ID de la station Weather Underground introuvable.",
+      "room_name_required": "Veuillez saisir un nom pour la pièce."
     },
     "create_entry": {
       "default": "Configuration terminée ! Vos prévisions locales et vos capteurs météo intelligents sont en cours de génération.\n\n**Prochaines étapes :**\nConfigurez le [tableau de bord](https://github.com/kmich/ha_ws_core/tree/main/dashboards)\n et les [automatisations d'alertes](https://github.com/kmich/ha_ws_core/tree/main/blueprints)"
@@ -966,7 +1004,7 @@
         "name": "Niveau du cours d'eau"
       },
       "rain_next_60min": {
-        "name": "Pluie dans les 60 min"
+        "name": "Pluie dans l'heure"
       },
       "minutes_until_rain": {
         "name": "Minutes avant la pluie"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha_ws_core"
-version = "2.6.0"
+version = "2.6.1"
 description = "Weather Station Core - Home Assistant integration for personal weather stations"
 requires-python = ">=3.12"
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -123,6 +123,15 @@ def _make_coordinator(**overrides):
 # ===========================================================================
 
 
+# Indoor rooms is a self-contained add/edit/remove mini-wizard (menu + CRUD
+# sub-forms), mirroring the identical, unguarded room_* steps that have
+# always existed in the Options flow's indoor_rooms_opt hub. Menu steps have
+# no data schema to carry a back-button field, and the CRUD sub-forms loop
+# back to their own hub rather than the outer linear step sequence, so the
+# whole mini-wizard is exempt from the back-button convention.
+ROOM_WIZARD_STEPS = {"indoor_rooms", "room_add", "room_edit", "room_form", "room_remove", "room_done"}
+
+
 class TestConfigFlowStructure:
     """Verify config flow step definitions and translation coverage."""
 
@@ -149,6 +158,8 @@ class TestConfigFlowStructure:
         for step_id, step_data in strings["config"]["step"].items():
             if step_id == "user":
                 assert "_go_back" not in step_data.get("data", {}), "user step should NOT have _go_back"
+            elif step_id in ROOM_WIZARD_STEPS:
+                continue
             else:
                 assert "_go_back" in step_data.get("data", {}), f"Step '{step_id}' missing _go_back"
 
@@ -197,7 +208,9 @@ class TestConfigFlowBackButton:
         config_section = content[: content.find("class WSStationOptionsFlowHandler")]
         # Count steps with back check
         steps = re.findall(r"async def async_step_(\w+)", config_section)
-        non_user = [s for s in steps if s != "user"]
+        # See ROOM_WIZARD_STEPS module comment: exempt from the back-button
+        # convention, same as the identical steps in the Options flow.
+        non_user = [s for s in steps if s != "user" and s not in ROOM_WIZARD_STEPS]
         back_calls = config_section.count("_handle_back")
         assert back_calls >= len(non_user), f"Expected >= {len(non_user)} _handle_back calls, found {back_calls}"
 


### PR DESCRIPTION
## Summary
- Merges #120 (adds named indoor rooms as a step in initial setup, mirroring the existing Options-flow hub) and #121 (French translations for those new steps) together, since neither works correctly on its own.
- Adds the missing `strings.json` / `translations/en.json` entries for the new config-flow steps (`indoor_rooms`, `room_edit`, `room_form`, `room_remove`) and the `room_name_required` error, which #120 introduced in code but never added English strings for. #121 only added the French side.
- As a side effect, #120 also fixes a pre-existing bug in the Options flow: when both Vigicrues and Indoor were enabled, finishing the Vigicrues step used to skip straight past the Indoor Rooms step to Upload Services.

Verified `config.step` / `config.error` key sets now match exactly across `strings.json`, `translations/en.json`, and `translations/fr.json`.

Closes #120, closes #121.

## Test plan
- [x] `python -m py_compile custom_components/ws_core/config_flow.py`
- [x] JSON validity check on all three translation files
- [x] Programmatic diff confirming `config.step`/`config.error` keys match across strings.json, en.json, fr.json
- [ ] Manual click-through of initial setup with "Enable Indoor" toggled on (add/edit/remove a room)
- [ ] Manual click-through of Options flow with both Vigicrues and Indoor enabled, confirming Indoor Rooms step is now reached