### PR TITLE
Release 2.6.2: security, correctness, and blueprint fixes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -68,25 +68,25 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Check manifest == diagnostics == pyproject
+      - name: Check manifest == pyproject
         run: |
           python - <<'PY'
           import json, pathlib, sys
           root = pathlib.Path(".")
           manifest = json.loads((root / "custom_components/ws_core/manifest.json").read_text())
           v = manifest["version"]
-          diag = (root / "custom_components/ws_core/diagnostics.py").read_text()
           pyproject = (root / "pyproject.toml").read_text()
           errors = []
-          if f'"{v}"' not in diag:
-              errors.append(f"diagnostics.py does not embed version {v!r}")
           if f'version = "{v}"' not in pyproject:
               errors.append(f"pyproject.toml does not embed version {v!r}")
+          # diagnostics.py reads the version from manifest.json at runtime (it does
+          # not embed a literal), so there is nothing to grep there -- the runtime
+          # behaviour is covered by tests/test_integration.py::test_diagnostics_version.
           if errors:
               for e in errors:
                   print("ERROR:", e)
               sys.exit(1)
-          print(f"OK: version {v!r} consistent across manifest.json, diagnostics.py, pyproject.toml")
+          print(f"OK: version {v!r} consistent across manifest.json and pyproject.toml")
           PY
 
   entity-validator:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,62 @@
 
 All notable changes to Weather Station Core are documented here.
 
+## [2.6.2] - 2026-07-03
+
+### Security
+
+- **Diagnostics no longer leak credentials.** The config-entry diagnostics export
+  previously included the full `entry.data` and `entry.options`, which contain
+  forecast and upload-network API keys, passwords, and passcodes (Weather
+  Underground, Weathercloud, PWSWeather, WOW, AWEKAS, OWM, Windy, CWOP, and the
+  forecast provider). All fields whose name looks like a credential
+  (`key`/`password`/`passcode`/`secret`/`token`/`auth`), plus location
+  coordinates, are now redacted, including inside nested per-network blocks.
+  If you shared a diagnostics export from an earlier version, rotate the exposed
+  keys.
+
+### Fixed
+
+- **User-renamed entities are no longer reverted on restart.** The sensor
+  platform used to force every entity id back to `sensor.{prefix}_{key}` on each
+  startup, silently undoing manual renames and splitting recorder history. Entity
+  ids are now set once at creation (fresh installs still get `sensor.ws_*`) and
+  then left under user control.
+- **Alert blueprints now respect their cooldown.** Several blueprints referenced
+  their inputs inside Jinja templates without mapping them into `variables:`, so
+  the value resolved to nothing. Most visibly, the `cooldown_hours` setting on the
+  frost, storm, and fire-danger alerts did nothing and alerts could repeat on
+  every trigger. All blueprint inputs used in templates are now mapped, and the
+  storm and fire-danger blueprints gained the missing cooldown condition.
+- **Penman-Monteith ET0 now uses your real latitude.** The FAO-56 ET0 calculation
+  hardcoded latitude 37 N for the extraterrestrial-radiation term, biasing the
+  irrigation figure for every site away from that latitude. It now uses the
+  configured location latitude.
+- **Fire Weather Index is correct in the Southern Hemisphere.** The DMC/DC
+  day-length tables were Northern-Hemisphere only, so seasonal drying was
+  six months out of phase south of the equator. `compute_fwi` now shifts the
+  tables based on the configured hemisphere.
+- **Timezone-correct time handling.** The current-condition classifier and the
+  weather-entity forecast alignment used the host clock (`datetime.now()`) instead
+  of the Home Assistant timezone; they now use `dt_util.now()`.
+- **Docs and badge fixes.** The README build badge pointed at `validate.yaml`
+  (the workflow is `validate.yml`); the sensors reference claimed an outdated
+  version; and the science docs incorrectly stated that 24h windows reset on
+  restart (they are persisted and restored).
+
+### Changed
+
+- **Sea-level pressure now uses a 12-hour mean temperature** for the hypsometric
+  reduction, as recommended by WMO, instead of the instantaneous temperature.
+  This removes a spurious diurnal wave from MSLP. Because MSLP feeds the Zambretti
+  forecast, the forecast-agreement sensor, and the local rain-probability index,
+  those values may shift slightly compared with earlier versions, especially at
+  higher-elevation stations. The reduction falls back to the instantaneous
+  temperature until at least an hour of history is available (for example, just
+  after setup).
+- ET0 and FWI values will change for sites affected by the two fixes above; this
+  is a correctness improvement, not a regression.
+
 ## [2.6.1] - 2026-07-01
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to Weather Station Core
+
+Thanks for your interest in improving `ws_core`. Contributions of code, translations,
+documentation, hardware-mapping notes, and forecast providers are all welcome.
+
+Please open an issue to discuss anything non-trivial before starting, so we can agree on
+the approach.
+
+## Quick start
+
+```bash
+pip install -r requirements_dev.txt
+python -m pytest          # run the test suite
+ruff check custom_components/
+ruff format --check custom_components/
+python scripts/validate_dashboard_entities.py
+```
+
+All of the above run in CI (`.github/workflows/validate.yml`); please make sure they pass
+locally before opening a pull request.
+
+## Where things live
+
+- Meteorological math: `custom_components/ws_core/algorithms.py` (pure functions, unit-tested).
+- Data pipeline: `custom_components/ws_core/coordinator.py`.
+- Config / options flow: `custom_components/ws_core/config_flow.py`.
+- Dashboards, blueprints, and docs: `dashboards/`, `blueprints/`, `docs/`.
+
+## Guidelines
+
+- Do not change a formula without a test and a `CHANGELOG.md` entry documenting the
+  before/after behaviour.
+- Preserve `unique_id`s and default entity ids; deprecate rather than delete.
+- Never hardcode a location, latitude, hemisphere, unit system, or device name.
+
+The full contribution guide, including the translation and forecast-provider workflows,
+lives in [docs/contributing.md](docs/contributing.md).
+
+## Reporting bugs
+
+Use the GitHub issue templates and attach your diagnostics export (credentials and
+coordinates are redacted automatically). See [SECURITY.md](SECURITY.md) for security
+issues.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026
+Copyright (c) 2026 Konstantinos Michalitsis
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The Intelligence Layer for your Home Assistant Weather Station.**
 
-Turn any weather station into a complete weather intelligence system: local forecasting, precipitation nowcasting, fire danger, irrigation, lightning detection, and data quality. 150+ sensors. Fully local-capable. No API keys required for core features.
+Turn any weather station into a complete weather intelligence system: local forecasting, precipitation nowcasting, fire danger, irrigation, lightning detection, and data quality. 50+ derived sensors out of the box, 150+ with every optional feature enabled. Fully local-capable. No API keys required for core features.
 
 ![Enhanced dashboard](screenshots/dashboard-advanced.png)
 
@@ -56,7 +56,7 @@ That's it! After the wizard completes, 50+ derived sensors appear automatically.
 
 | Mobile View | Desktop View |
 |---|---|
-| ![Mobile dashboard](screenshots/dashboard-weather.png) | ![Desktop dashboard](screenshots/dashboard-advanced.png) |
+| ![Mobile dashboard](screenshots/mobile_dashboard.png) | ![Desktop dashboard](screenshots/dashboard-advanced.png) |
 
 Check out the `dashboards/` directory for the YAML code. We provide:
 * A `vanilla` dashboard using only native HA cards.
@@ -93,6 +93,29 @@ For the math, citations, and formulas behind these features, read the [**Scienti
 
 ---
 
+## 🔒 Data & Privacy
+
+`ws_core` is local-first. All core derived sensors are computed on your machine from
+your own station data and never leave your network. Every feature that sends data to a
+third party is **opt-in and disabled by default**, so nothing is transmitted until you
+turn it on in **Configure → Features**.
+
+When you enable them, the following optional features contact external services:
+
+| Feature | Destination | Data sent |
+|---|---|---|
+| Forecast (Open-Meteo, Met.no, NWS, OWM, Pirate Weather, Météo France, HA entity) | The selected provider | Your coordinates |
+| Precipitation nowcast, air quality, pollen, sea temperature, solar forecast | Open-Meteo / forecast.solar | Your coordinates |
+| French Vigilance / Vigicrues | Météo-France public APIs | Your department / nearest station |
+| Network uploads (WUnderground, Weathercloud, PWSWeather, WOW, AWEKAS, CWOP, OWM, Windy) | Each network you enable | Your live observations and that network's credentials |
+| MQTT republishing | Your own MQTT broker | Derived sensor values |
+
+API keys and passwords you enter are stored in the Home Assistant config entry. The
+diagnostics export **redacts** all credentials and coordinates, so it is safe to attach
+to a bug report.
+
+---
+
 ## ❓ FAQ & Troubleshooting
 
 * **Why are my entities unavailable?**
@@ -103,6 +126,12 @@ For the math, citations, and formulas behind these features, read the [**Scienti
   We have a dedicated [migration guide](docs/migrating_from_thermal_comfort.md) with step-by-step instructions.
 * **Do I need an API Key?**
   No. All core features run completely offline locally. Optional features like Air Quality or Nowcast use free APIs that require no registration.
+* **Which fire-danger number should I trust?**
+  Use the one calibrated for your region: **FFDI** (`sensor.ws_ffdi`) in Australia and New Zealand, **FWI** (`sensor.ws_fwi`, Canadian system) elsewhere, and **FFWI** (`sensor.ws_ffwi`) as a US/global cross-check. `sensor.ws_fire_risk_score` is a simplified 1-10 display value. None of these is an official warning - always defer to your local fire authority.
+* **Which ET0 should I use for irrigation?**
+  If you have mapped a solar-radiation sensor, prefer `sensor.ws_et0_pm_daily` (FAO-56 Penman-Monteith, the reference method). Without solar radiation, use `sensor.ws_et0_daily` (Hargreaves-Samani, ±15-20%).
+* **How do I uninstall?**
+  Go to **Settings → Devices & Services → Weather Station Core → ⋮ → Delete**. This removes the integration, its device, and all derived entities and their history. To remove the code as well, delete the repository from **HACS → Integrations**. Any dashboards or blueprints you imported are independent and can be removed separately.
 
 ---
 
@@ -112,7 +141,7 @@ For the math, citations, and formulas behind these features, read the [**Scienti
 [release-url]: https://github.com/kmich/ha_ws_core/releases
 [license-badge]: https://img.shields.io/github/license/kmich/ha_ws_core?style=for-the-badge
 [license-url]: https://github.com/kmich/ha_ws_core/blob/main/LICENSE
-[validate-badge]: https://img.shields.io/github/actions/workflow/status/kmich/ha_ws_core/validate.yaml?branch=main&label=validate&style=for-the-badge
-[validate-url]: https://github.com/kmich/ha_ws_core/actions/workflows/validate.yaml
+[validate-badge]: https://img.shields.io/github/actions/workflow/status/kmich/ha_ws_core/validate.yml?branch=main&label=validate&style=for-the-badge
+[validate-url]: https://github.com/kmich/ha_ws_core/actions/workflows/validate.yml
 [translation-badge]: https://img.shields.io/badge/Translations-8-blue?style=for-the-badge
 [translation-url]: https://github.com/kmich/ha_ws_core/tree/main/custom_components/ws_core/translations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported versions
+
+Weather Station Core is a community project. Security fixes are applied to the latest
+released version. Please make sure you are on the current release before reporting.
+
+## Reporting a vulnerability
+
+Please report suspected security issues **privately** rather than in a public issue:
+
+- Use GitHub's **Report a vulnerability** button under the repository's **Security** tab
+  (Private vulnerability reporting), or
+- open a minimal issue asking for a private contact channel, without including any
+  sensitive details.
+
+Please include the affected version, a description of the issue, and reproduction steps.
+We aim to acknowledge reports within a few days.
+
+## Handling credentials
+
+`ws_core` can store API keys and passwords for optional forecast providers and upload
+networks in the Home Assistant config entry. The diagnostics export redacts all
+credential-like fields and location coordinates, so it is safe to attach to a bug report.
+If you shared a diagnostics export produced before v2.6.2, rotate any keys it may have
+contained, as earlier versions did not redact them.

--- a/blueprints/automation/ws_core/fire_danger_alert.yaml
+++ b/blueprints/automation/ws_core/fire_danger_alert.yaml
@@ -49,12 +49,22 @@ blueprint:
           min: 1
           max: 24
 
+variables:
+  garden_switch: !input garden_switch
+  cooldown_hours: !input cooldown_hours
+
 trigger:
   - platform: numeric_state
     entity_id: !input fire_sensor
     above: !input fire_threshold
     for:
       minutes: 15
+
+condition:
+  - condition: template
+    value_template: >
+      {% set last = state_attr(this.entity_id, 'last_triggered') %}
+      {{ last is none or (now() - last).total_seconds() / 3600 > (cooldown_hours | int) }}
 
 action:
   - service: !input notify_target

--- a/blueprints/automation/ws_core/frost_alert.yaml
+++ b/blueprints/automation/ws_core/frost_alert.yaml
@@ -41,6 +41,7 @@ blueprint:
 
 variables:
   threshold: !input freeze_threshold
+  cooldown_hours: !input cooldown_hours
 
 trigger:
   - platform: numeric_state

--- a/blueprints/automation/ws_core/irrigation_rain_skip.yaml
+++ b/blueprints/automation/ws_core/irrigation_rain_skip.yaml
@@ -64,6 +64,14 @@ blueprint:
       selector:
         text:
 
+variables:
+  rain_today_sensor: !input rain_today_sensor
+  rain_skip_threshold_mm: !input rain_skip_threshold_mm
+  rain_probability_sensor: !input rain_probability_sensor
+  rain_prob_threshold: !input rain_prob_threshold
+  duration_minutes: !input duration_minutes
+  notify_target: !input notify_target
+
 trigger:
   - platform: time
     at: !input schedule_time

--- a/blueprints/automation/ws_core/lightning_safety.yaml
+++ b/blueprints/automation/ws_core/lightning_safety.yaml
@@ -39,6 +39,10 @@ blueprint:
           max: 60
           step: 5
 
+variables:
+  pool_switch: !input pool_switch
+  lightning_clearance_sensor: !input lightning_clearance_sensor
+
 trigger:
   - platform: state
     entity_id: !input lightning_proximity_sensor

--- a/blueprints/automation/ws_core/storm_alert.yaml
+++ b/blueprints/automation/ws_core/storm_alert.yaml
@@ -38,12 +38,23 @@ blueprint:
           max: 12
           step: 1
 
+variables:
+  rain_probability_sensor: !input rain_probability_sensor
+  wind_gust_sensor: !input wind_gust_sensor
+  cooldown_hours: !input cooldown_hours
+
 trigger:
   - platform: numeric_state
     entity_id: !input pressure_trend_sensor
     below: -1.6
     for:
       minutes: 10
+
+condition:
+  - condition: template
+    value_template: >
+      {% set last = state_attr(this.entity_id, 'last_triggered') %}
+      {{ last is none or (now() - last).total_seconds() / 3600 > (cooldown_hours | int) }}
 
 action:
   - service: !input notify_target

--- a/custom_components/ws_core/algorithms.py
+++ b/custom_components/ws_core/algorithms.py
@@ -262,17 +262,27 @@ def clearness_to_cloud_cover(kt: float) -> int:
 # ---------------------------------------------------------------------------
 
 
-def calculate_sea_level_pressure(station_pressure_hpa: float, elevation_m: float, temp_c: float) -> float:
+def calculate_sea_level_pressure(
+    station_pressure_hpa: float,
+    elevation_m: float,
+    temp_c: float,
+    mean_temp_c: float | None = None,
+) -> float:
     """Reduce station pressure to mean sea level (MSLP).
 
     Method: Temperature-corrected hypsometric reduction (WMO No. 8, S3.1.3).
     Formula: MSLP = P_stn * exp(elevation / (T_K * 29.263))
 
     Accuracy: +/-0.3 hPa below 500 m, +/-1 hPa at 2000 m.
-    Limitation: Uses current temperature only; WMO recommends 12h mean
-    temperature for better accuracy at high elevations.
+
+    WMO recommends the 12-hour mean temperature for the reduction, because
+    using the instantaneous temperature injects a spurious diurnal wave into
+    MSLP (and therefore into the pressure trend and Zambretti forecast that
+    consume it). Pass ``mean_temp_c`` with the 12h mean when available; the
+    function falls back to ``temp_c`` when it is not.
     """
-    temp_k = temp_c + 273.15
+    t_reduction = mean_temp_c if mean_temp_c is not None else temp_c
+    temp_k = t_reduction + 273.15
     if temp_k < 1.0:
         temp_k = 1.0  # guard against division by zero
     exponent = elevation_m / (temp_k * 29.263)
@@ -821,6 +831,7 @@ def determine_current_condition(
     is_day,
     pm10=0.0,
     is_wet=False,
+    current_hour=None,
 ) -> str:
     """Classify current weather into one of 36 conditions.
 
@@ -830,6 +841,10 @@ def determine_current_condition(
     Limitation: Uses raw illuminance as cloud proxy without solar-angle
     normalization. Cloud cover estimates are approximate -- accuracy
     improves with higher sun elevation angles.
+
+    ``current_hour`` is the local hour (0-23) in the Home Assistant timezone,
+    used only to distinguish a misty morning from generic fog. Callers should
+    pass ``dt_util.now().hour``; when omitted it falls back to the host clock.
     """
     is_rising = sun_azimuth < 180
     is_golden_hour = -4 < sun_elevation < 10 and is_day
@@ -868,7 +883,7 @@ def determine_current_condition(
 
     # Visibility
     if humidity > 95 and (temp_c - (dew_point_c or temp_c)) < 1 and wind_speed_ms < 1.5:
-        now_h = datetime.now().hour
+        now_h = current_hour if current_hour is not None else datetime.now().hour
         return "misty-morning" if (is_sunrise or 5 <= now_h < 9) else "fog"
 
     # Air quality
@@ -1094,6 +1109,7 @@ def compute_fwi(
     wind_kmh: float,
     rain_24h_mm: float,
     month: int,
+    hemisphere: str = "northern",
 ) -> dict:
     """Canadian Forest Fire Weather Index (FWI) system - Van Wagner 1987.
 
@@ -1115,7 +1131,12 @@ def compute_fwi(
         rh_pct:    Noon relative humidity (%).
         wind_kmh:  Noon wind speed (km/h).
         rain_24h_mm: 24-hour cumulative rainfall (mm).
-        month:     Calendar month (1=January … 12=December), Northern Hemisphere.
+        month:     Calendar month (1=January … 12=December).
+        hemisphere: "northern" or "southern". The DMC/DC day-length tables are
+            defined for the Northern Hemisphere; for "southern" the month index
+            is shifted by six months so seasonal drying matches the local
+            season (e.g. a January in the Southern Hemisphere uses July's
+            day-length factors).
 
     Returns:
         dict with keys: ffmc, dmc, dc, isi, bui, fwi, dsr  (all float, rounded to 1 d.p.)
@@ -1128,6 +1149,10 @@ def compute_fwi(
     P0 = float(dmc_prev)
     D0 = float(dc_prev)
     month_i = max(1, min(12, int(month)))
+    # Day-length tables (Le, Lf below) are Northern-Hemisphere. In the Southern
+    # Hemisphere the seasons are offset by six months, so index them with a
+    # shifted month. day_len_idx is 0-based into the 12-element tables.
+    day_len_idx = (month_i - 1 + 6) % 12 if str(hemisphere).lower() == "southern" else month_i - 1
 
     # -----------------------------------------------------------------------
     # FFMC - Fine Fuel Moisture Code
@@ -1189,7 +1214,7 @@ def compute_fwi(
         P0 = max(pr, 0.0)
 
     if T > -1.1:
-        K = 1.894 * (T + 1.1) * (100.0 - H) * Le[month_i - 1] * 1e-6
+        K = 1.894 * (T + 1.1) * (100.0 - H) * Le[day_len_idx] * 1e-6
         dmc = P0 + 100.0 * K
     else:
         dmc = P0
@@ -1208,7 +1233,7 @@ def compute_fwi(
         Dr = 400.0 * math.log(800.0 / Qr)
         D0 = max(Dr, 0.0)
 
-    V = max(0.0, 0.36 * (T + 2.8) + Lf[month_i - 1]) if T > -2.8 else max(0.0, Lf[month_i - 1])
+    V = max(0.0, 0.36 * (T + 2.8) + Lf[day_len_idx]) if T > -2.8 else max(0.0, Lf[day_len_idx])
     dc = D0 + 0.5 * V
     dc = max(0.0, dc)
 
@@ -1652,6 +1677,7 @@ def et0_penman_monteith(
     solar_radiation_wm2: float,
     elevation_m: float = 0.0,
     day_of_year: int = 180,
+    latitude_deg: float = 0.0,
 ) -> float:
     """Reference evapotranspiration via FAO-56 Penman-Monteith method.
 
@@ -1673,6 +1699,10 @@ def et0_penman_monteith(
         Station elevation above sea-level (m).
     day_of_year : int
         Julian day of year (1-365), used for net longwave correction.
+    latitude_deg : float
+        Station latitude in decimal degrees, used for the extraterrestrial
+        radiation term. Pass the real site latitude; defaults to 0 (equator)
+        only when latitude is unknown.
 
     Returns
     -------
@@ -1717,10 +1747,12 @@ def et0_penman_monteith(
     # Net shortwave radiation Rns  FAO56 Eq 38 (α=0.23 for reference grass)
     Rns = (1 - 0.23) * Rs
 
-    # Extraterrestrial radiation Ra for net longwave estimate  FAO56 Eq 21
-    _phi = math.radians(max(-90, min(90, z)))  # use elevation as lat proxy - caller should pass lat
-    # Simplified Ra (mean for mid-latitudes when lat not separately passed)
-    Ra = extraterrestrial_radiation_mj(37.0, doy)  # fallback 37°N
+    # Extraterrestrial radiation Ra for net longwave estimate  FAO56 Eq 21.
+    # Uses the station's true latitude; callers should pass latitude_deg. A
+    # value of 0 degrees (the equator, and the default) keeps the function
+    # usable when latitude is genuinely unknown.
+    lat = max(-90.0, min(90.0, float(latitude_deg)))
+    Ra = extraterrestrial_radiation_mj(lat, doy)
 
     # Clear-sky solar radiation Rso  FAO56 Eq 37
     Rso = (0.75 + 2e-5 * z) * Ra

--- a/custom_components/ws_core/coordinator.py
+++ b/custom_components/ws_core/coordinator.py
@@ -1380,6 +1380,20 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return [v for _, v in history]
 
     @staticmethod
+    def _mean_window(history: deque, now: Any, hours: float, min_samples: int = 1) -> float | None:
+        """Mean of ``(ts, value)`` samples within the last ``hours``.
+
+        Returns ``None`` when fewer than ``min_samples`` samples fall inside the
+        window, so callers can fall back to an instantaneous value instead of a
+        misleading average built from too little history.
+        """
+        cutoff = now - timedelta(hours=hours)
+        vals = [v for ts, v in history if ts >= cutoff]
+        if len(vals) < min_samples:
+            return None
+        return sum(vals) / len(vals)
+
+    @staticmethod
     def _rain_accum_24h_from_totals(history: deque) -> float:
         vals = [v for _, v in history]
         total = 0.0
@@ -1708,7 +1722,12 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         mslp: float | None = None
         if pressure_hpa is not None and tc is not None:
-            mslp = calculate_sea_level_pressure(float(pressure_hpa), self.elevation_m, float(tc))
+            # WMO reduces station pressure with a 12h mean temperature to avoid a
+            # spurious diurnal wave. Use the mean over the last 12h of samples
+            # when we have a meaningful amount of history; otherwise fall back to
+            # the instantaneous reading (e.g. shortly after first setup).
+            mean_temp = self._mean_window(rt.temp_history_24h, now, hours=12.0, min_samples=6)
+            mslp = calculate_sea_level_pressure(float(pressure_hpa), self.elevation_m, float(tc), mean_temp_c=mean_temp)
             data[KEY_SEA_LEVEL_PRESSURE_HPA] = mslp
             rt.last_mslp = mslp
 
@@ -1970,6 +1989,7 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             sun_elevation=sun_elev,
             sun_azimuth=sun_azimuth,
             is_day=is_day,
+            current_hour=dt_util.now().hour,
         )
         data[KEY_CURRENT_CONDITION] = condition
         data["_condition_icon"] = CONDITION_ICONS.get(condition, "mdi:weather-partly-cloudy")
@@ -3483,6 +3503,7 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     wind_kmh=wind_kmh,
                     rain_24h_mm=rain_24h,
                     month=fwi_month,
+                    hemisphere=self.hemisphere,
                 )
                 self._learning_state.fwi_ffmc = fwi_result["ffmc"]
                 self._learning_state.fwi_dmc = fwi_result["dmc"]
@@ -3500,6 +3521,7 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     wind_kmh=wind_kmh,
                     rain_24h_mm=0.0,  # rain already applied today
                     month=fwi_month,
+                    hemisphere=self.hemisphere,
                 )
 
             data[KEY_FWI_FFMC] = fwi_result["ffmc"]
@@ -3816,6 +3838,7 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     solar_radiation_wm2=float(sol_rad),
                     elevation_m=self.elevation_m,
                     day_of_year=doy,
+                    latitude_deg=float(self.forecast_lat),
                 )
                 data[KEY_ET0_PM_DAILY_MM] = et0_pm
 

--- a/custom_components/ws_core/diagnostics.py
+++ b/custom_components/ws_core/diagnostics.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+import pathlib
+import re
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -14,17 +17,51 @@ from .const import (
     KEY_SENSOR_QUALITY_FLAGS,
 )
 
+REDACTED = "**REDACTED**"
 
-def _redact_coords(d: dict[str, Any]) -> dict[str, Any]:
-    """Redact location data for privacy."""
-    out = dict(d)
-    out.pop("forecast_lat", None)
-    out.pop("forecast_lon", None)
-    return out
+
+def _integration_version() -> str:
+    """Read the integration version from the sibling manifest.json.
+
+    Resolved once at import time (the diagnostics platform module is imported in
+    the executor), so it never reads a file inside the event loop at request
+    time and stays in sync with manifest.json without a hardcoded literal.
+    """
+    try:
+        manifest = pathlib.Path(__file__).parent / "manifest.json"
+        return str(json.loads(manifest.read_text(encoding="utf-8")).get("version", "unknown"))
+    except Exception:  # pragma: no cover - manifest is always present in practice
+        return "unknown"
+
+
+_VERSION = _integration_version()
+
+# Location keys are redacted for privacy; anything whose key name matches this
+# pattern is a credential (API key, password, passcode, auth/secret/token) and
+# must never appear in a diagnostics export that users routinely attach to
+# public bug reports.
+_LOCATION_KEYS = frozenset({"forecast_lat", "forecast_lon", "sea_temp_lat", "sea_temp_lon"})
+_SECRET_KEY_RE = re.compile(r"(key|password|passcode|secret|token|auth)", re.IGNORECASE)
+
+
+def _redact(value: Any, key: str | None = None) -> Any:
+    """Recursively redact secrets and location data.
+
+    A value is redacted when its own key name matches a secret pattern or is a
+    known location field.  Redaction recurses into nested dicts and lists so
+    per-network credential blocks are covered too.
+    """
+    if key is not None and (key in _LOCATION_KEYS or _SECRET_KEY_RE.search(key)):
+        return REDACTED if value not in (None, "") else value
+    if isinstance(value, dict):
+        return {k: _redact(v, k) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact(v) for v in value]
+    return value
 
 
 async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigEntry) -> dict[str, Any]:
-    """Return diagnostics for a config entry."""
+    """Return diagnostics for a config entry (secrets and coordinates redacted)."""
     coord = hass.data.get(DOMAIN, {}).get(entry.entry_id)
     data = coord.data if coord else None
 
@@ -56,9 +93,9 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigE
 
     return {
         "title": entry.title,
-        "version": "2.6.1",
-        "entry_data": _redact_coords(dict(entry.data)),
-        "entry_options": _redact_coords(dict(entry.options)),
+        "version": _VERSION,
+        "entry_data": _redact(dict(entry.data)),
+        "entry_options": _redact(dict(entry.options)),
         "sources": sources,
         "sensor_stats": sensor_stats,
         "runtime": runtime_info,

--- a/custom_components/ws_core/manifest.json
+++ b/custom_components/ws_core/manifest.json
@@ -10,8 +10,9 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/kmich/ha_ws_core",
+  "integration_type": "service",
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/kmich/ha_ws_core/issues",
   "requirements": [],
-  "version": "2.6.1"
+  "version": "2.6.2"
 }

--- a/custom_components/ws_core/sensor.py
+++ b/custom_components/ws_core/sensor.py
@@ -10,7 +10,6 @@ from typing import Any
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -2663,12 +2662,13 @@ class WSSensor(RestoreEntity, CoordinatorEntity, SensorEntity):
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
-        desired = f"sensor.{self._attr_suggested_object_id}"
-        if self.entity_id and self.entity_id != desired:
-            reg = er.async_get(self.hass)
-            current = reg.async_get(self.entity_id)
-            if current and current.unique_id == self.unique_id and reg.async_get(desired) is None:
-                reg.async_update_entity(self.entity_id, new_entity_id=desired)
+        # The entity_id is set once at creation from _attr_suggested_object_id
+        # (Home Assistant honours it the first time the entity is registered),
+        # which yields sensor.{prefix}_{key} on a fresh install. We deliberately
+        # do NOT force the entity_id back to that value on later startups: once
+        # an entity exists in the registry, its entity_id belongs to the user,
+        # and rewriting it here would silently revert any manual rename on every
+        # restart and split the entity's recorder history.
 
         # Restore last known value for sensors that are slow to warm up
         if self._desc.key in self._RESTORE_KEYS:

--- a/custom_components/ws_core/weather.py
+++ b/custom_components/ws_core/weather.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Any
 
 from homeassistant.components.weather import WeatherEntity
@@ -22,6 +21,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_PREFIX,
@@ -223,7 +223,7 @@ class WSStationWeather(CoordinatorEntity, WeatherEntity):
         fc = d.get(KEY_FORECAST) or {}
         hourly = fc.get("hourly") or []
         if hourly:
-            now_iso = datetime.now().strftime("%Y-%m-%dT%H:00")
+            now_iso = dt_util.now().strftime("%Y-%m-%dT%H:00")
             for item in hourly:
                 if str(item.get("datetime", "")).startswith(now_iso[:13]):
                     h_cond = _weathercode_to_condition(item.get("weathercode"))
@@ -286,7 +286,7 @@ class WSStationWeather(CoordinatorEntity, WeatherEntity):
         local_gust_ms = d.get(KEY_NORM_WIND_GUST_MS)
         local_condition = d.get(KEY_CURRENT_CONDITION)
         local_rain_rate = d.get(KEY_RAIN_RATE_FILT)  # mm/h  → approx mm in 1h
-        now_hour_iso = datetime.now().strftime("%Y-%m-%dT%H")
+        now_hour_iso = dt_util.now().strftime("%Y-%m-%dT%H")
         nowcast_slot = 0  # counts how many hourly slots we've applied local data to
 
         out: list[dict[str, Any]] = []

--- a/docs/entity_map.html
+++ b/docs/entity_map.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>WS Core 2.6.0 - Entity Map</title>
+<title>WS Core 2.6.2 - Entity Map</title>
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 body{background:#0f1117;color:#e2e8f0;font-family:system-ui,sans-serif;padding:24px 20px;max-width:1050px;margin:0 auto}
@@ -33,9 +33,9 @@ small{font-size:10px}
 <header>
   <h1>⛅ Weather Station Core - Entity Map</h1>
   <div class="meta">
-    <span>🔖 v2.6.0</span>
+    <span>🔖 v2.6.2</span>
     <span>📦 159 sensor entities + 28 switches</span>
-    <span>🕐 Generated 2026-06-30T14:53:07Z</span>
+    <span>🕐 Generated 2026-07-04T08:38:05Z</span>
   </div>
 </header>
 <div class="legend">

--- a/docs/forecast_providers.md
+++ b/docs/forecast_providers.md
@@ -84,6 +84,33 @@ attribute on older installations.
 
 ---
 
+## How ws_core combines sources
+
+There is a single active forecast provider at a time (the one you select). ws_core does
+not silently fail over to a different provider, so the source of every forecast value is
+always predictable and shown in `sensor.ws_forecast_provider`. The provider result is
+cached and refreshed on a fixed cadence (about every 15 minutes); if a refresh fails,
+the last good forecast is retained and the forecast sensors stay available rather than
+dropping to `unknown`.
+
+Local station data and the provider forecast are combined in three explicit places, in
+this order of trust for the near term:
+
+1. **Nowcast (0-2 hours):** your live rain gauge is blended with the Open-Meteo
+   15-minute grid (a tapering 70 / 40 / 10 % local weight over the first three hours),
+   because your own gauge is the ground truth for what is happening right now.
+2. **Rain probability:** a local barometric/wind heuristic is blended with the provider
+   precipitation probability. When at least ten verified outcomes exist, the blend weight
+   is learned from each source's rolling 90-day Brier score; otherwise a fixed
+   time-of-day weight is used.
+3. **Forecast agreement:** `sensor.ws_forecast_agreement` compares the local Zambretti
+   outlook against the provider probability and reports `aligned` / `diverging` /
+   `conflict`, so a disagreement is surfaced rather than hidden.
+
+Beyond the first few hours, the selected provider's forecast is used as-is.
+
+---
+
 ## Adding a new provider
 
 See [Contributing](contributing.md) for the provider contribution path.

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,7 @@ See the [Quickstart](quickstart.md) for a 5-minute installation walkthrough.
 
 ## Project status
 
-- **Version:** 2.5.2 (June 2026)
+- **Version:** see [latest release](https://github.com/kmich/ha_ws_core/releases)
 - **License:** MIT
 - **Repository:** [github.com/kmich/ha_ws_core](https://github.com/kmich/ha_ws_core)
 - **Issues:** [GitHub Issues](https://github.com/kmich/ha_ws_core/issues)

--- a/docs/science.md
+++ b/docs/science.md
@@ -54,6 +54,11 @@ T_w = T · atan(0.151977 · (RH + 8.313659)^0.5)
 MSLP = P_station × exp(elevation_m / (T_K × 29.263))
 ```
 
+`T_K` is the **12-hour mean** temperature (in kelvin), as recommended by WMO, rather
+than the instantaneous reading. This avoids a spurious day/night wave in MSLP. Until
+at least an hour of history has accumulated (for example just after setup), the
+instantaneous temperature is used as a fallback.
+
 **Accuracy:** ±0.3 hPa below 500 m, ±1 hPa at 2000 m.
 **Reference:** WMO No. 8 — Guide to Meteorological Instruments and Methods of Observation, Annex 3A.
 
@@ -261,7 +266,9 @@ Six physical-impossibility checks per coordinator update:
 
 ## Sensor Calibration {#calibration}
 
-All offsets are applied after unit conversion, before all derived calculations.
+Each source reading is first converted to canonical metric units (°C, hPa, m/s, mm),
+then the calibration offset is added, and only then are the derived metrics computed.
+So an offset is always expressed in metric units regardless of your display units.
 
 | Offset | Range | Typical use |
 |---|---|---|
@@ -289,11 +296,15 @@ Download diagnostics via **Settings → Devices & Services → Weather Station C
 ## Known Limitations
 
 1. Illuminance-based cloud detection uses raw lux without solar-angle normalization. Accuracy degrades at low sun elevation angles.
-2. Sea-level pressure uses current temperature only, not the WMO-recommended 12h mean.
+2. Sea-level pressure uses the WMO-recommended 12h mean temperature once enough
+   history exists, and falls back to the current temperature during the first hour
+   of operation.
 3. Rain probability is a heuristic index, not a statistically calibrated probability.
 4. FWI moisture codes are initialised at Van Wagner's standard defaults on first run and self-correct within a few days.
 5. Thunderstorm Risk is a surface-based proxy only and cannot detect elevated convection.
-6. 24h statistics are computed from in-memory rolling windows and reset on HA restart.
+6. 24h statistics are computed from rolling windows that are persisted to disk and
+   restored on HA restart, so a normal restart preserves them. Extended downtime
+   still leaves a gap in the window until it refills.
 
 ---
 

--- a/docs/sensors.md
+++ b/docs/sensors.md
@@ -1,6 +1,6 @@
 # Sensors Reference
 
-Complete list of entities created by Weather Station Core at v2.1.0.
+Complete list of entities created by Weather Station Core.
 
 Entity IDs shown use the default prefix `ws`. If you chose a different prefix during
 setup, replace `ws` with your prefix.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha_ws_core"
-version = "2.6.1"
+version = "2.6.2"
 description = "Weather Station Core - Home Assistant integration for personal weather stations"
 requires-python = ">=3.12"
 

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -225,8 +225,36 @@ class TestET0:
             solar_radiation_wm2=600.0,
             elevation_m=50.0,
             day_of_year=180,
+            latitude_deg=37.0,
         )
         assert 4.0 < et0 < 12.0
+
+    def test_penman_monteith_latitude_sensitivity(self):
+        """ET0 must depend on the supplied latitude (the net-longwave term uses Ra).
+
+        On day-of-year 180 (late June) the sub-tropics receive very different
+        extraterrestrial radiation than high latitudes, so identical weather at
+        10 deg N vs 60 deg N must not yield the same ET0. This guards against the
+        old bug where latitude was hardcoded to 37 N for every site.
+        """
+        # A realistic daily-mean shortwave (200 W/m2) keeps Rs/Rso below the
+        # clear-sky clamp so the latitude-dependent longwave term is active.
+        kwargs = dict(
+            temp_mean_c=28.0,
+            temp_max_c=34.0,
+            temp_min_c=22.0,
+            humidity=55.0,
+            wind_speed_ms=3.0,
+            solar_radiation_wm2=200.0,
+            elevation_m=50.0,
+            day_of_year=180,
+        )
+        et0_low = et0_penman_monteith(latitude_deg=10.0, **kwargs)
+        et0_high = et0_penman_monteith(latitude_deg=60.0, **kwargs)
+        assert et0_low != et0_high
+        # Both must remain physically plausible.
+        assert 3.0 < et0_low < 9.0
+        assert 3.0 < et0_high < 9.0
 
 
 class TestKalman:
@@ -469,6 +497,22 @@ class TestSeaLevelPressureReferenceValues:
         slp_warm = calculate_sea_level_pressure(1000.0, 500.0, 30.0)
         assert slp_cold > slp_warm
 
+    def test_mean_temp_overrides_instantaneous(self):
+        """When mean_temp_c is given it drives the reduction, not temp_c."""
+        # Instantaneous 30 C but a cooler 12h mean of 10 C: result must match
+        # a plain reduction at 10 C, not at 30 C.
+        with_mean = calculate_sea_level_pressure(1000.0, 500.0, 30.0, mean_temp_c=10.0)
+        plain_10 = calculate_sea_level_pressure(1000.0, 500.0, 10.0)
+        plain_30 = calculate_sea_level_pressure(1000.0, 500.0, 30.0)
+        assert with_mean == plain_10
+        assert with_mean != plain_30
+
+    def test_mean_temp_none_falls_back_to_instantaneous(self):
+        """Omitting mean_temp_c preserves the original behaviour."""
+        assert calculate_sea_level_pressure(1000.0, 500.0, 18.0) == calculate_sea_level_pressure(
+            1000.0, 500.0, 18.0, mean_temp_c=None
+        )
+
 
 class TestZambrettiReferenceValues:
     """Zambretti barometric forecaster."""
@@ -601,6 +645,38 @@ class TestCanadianFWIReferenceValues:
         for key in ("ffmc", "dmc", "dc", "isi", "bui", "fwi", "dsr"):
             assert key in result, f"Missing key: {key}"
             assert result[key] >= 0.0, f"{key}={result[key]} is negative"
+
+    def test_hemisphere_shifts_seasonal_drying(self):
+        """Southern Hemisphere must use season-shifted day-length tables.
+
+        In January the Northern tables give a short day-length (low drying),
+        while the Southern Hemisphere is in mid-summer (high drying). The DMC
+        and DC moisture codes must therefore differ between hemispheres for the
+        same January weather. This guards against the old Northern-only tables.
+        """
+        common = dict(
+            ffmc_prev=85.0,
+            dmc_prev=6.0,
+            dc_prev=15.0,
+            temp_c=25.0,
+            rh_pct=40.0,
+            wind_kmh=15.0,
+            rain_24h_mm=0.0,
+            month=1,  # January
+        )
+        north = compute_fwi(**common, hemisphere="northern")
+        south = compute_fwi(**common, hemisphere="southern")
+        assert south["dmc"] != north["dmc"]
+        assert south["dc"] != north["dc"]
+        # Southern-Hemisphere January (summer) must dry faster than Northern
+        # January (winter): higher DMC and DC.
+        assert south["dmc"] > north["dmc"]
+        assert south["dc"] > north["dc"]
+
+    def test_default_hemisphere_is_northern(self):
+        """Omitting hemisphere must match explicit northern (backwards compatible)."""
+        args = (85.0, 6.0, 15.0, 22.0, 45.0, 12.0, 0.0, 3)
+        assert compute_fwi(*args) == compute_fwi(*args, hemisphere="northern")
 
 
 class TestRainProbabilityReferenceValues:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -452,13 +452,60 @@ class TestDiagnostics:
         assert result["data_quality"] == "OK"
 
     def test_diagnostics_redacts_coords(self):
-        from custom_components.ws_core.diagnostics import _redact_coords
+        from custom_components.ws_core.diagnostics import REDACTED, _redact
 
         data = {"forecast_lat": 37.9, "forecast_lon": 23.7, "name": "Test"}
-        redacted = _redact_coords(data)
-        assert "forecast_lat" not in redacted
-        assert "forecast_lon" not in redacted
+        redacted = _redact(dict(data))
+        assert redacted["forecast_lat"] == REDACTED
+        assert redacted["forecast_lon"] == REDACTED
         assert redacted["name"] == "Test"
+
+    def test_diagnostics_redacts_all_credentials(self):
+        """No credential-bearing key may survive in diagnostics output."""
+        from custom_components.ws_core.diagnostics import REDACTED, _redact
+
+        secrets = {
+            "forecast_api_key": "abc123",
+            "wu_api_key": "wu-secret",
+            "wc_api_key": "wc-secret",
+            "pws_api_key": "pws-secret",
+            "wow_auth_key": "wow-secret",
+            "awekas_password": "hunter2",
+            "owm_stations_api_key": "owm-secret",
+            "windy_api_key": "windy-secret",
+            "cwop_passcode": "12345",
+            "tomorrow_io_key": "tio-secret",
+            # nested per-network block must be redacted too
+            "nested": {"pws_api_key": "nested-secret", "prefix": "ws"},
+            # non-secret fields must be preserved
+            "prefix": "ws",
+            "elevation": 120,
+        }
+        redacted = _redact(dict(secrets))
+        for key in (
+            "forecast_api_key",
+            "wu_api_key",
+            "wc_api_key",
+            "pws_api_key",
+            "wow_auth_key",
+            "awekas_password",
+            "owm_stations_api_key",
+            "windy_api_key",
+            "cwop_passcode",
+            "tomorrow_io_key",
+        ):
+            assert redacted[key] == REDACTED, f"{key} leaked"
+        assert redacted["nested"]["pws_api_key"] == REDACTED
+        assert redacted["nested"]["prefix"] == "ws"
+        assert redacted["prefix"] == "ws"
+        assert redacted["elevation"] == 120
+
+        # No original secret VALUE should appear anywhere in the serialized output.
+        import json as _json
+
+        blob = _json.dumps(redacted)
+        for leaked in ("abc123", "wu-secret", "hunter2", "nested-secret", "windy-secret"):
+            assert leaked not in blob
 
     def test_diagnostics_handles_no_coordinator(self):
         import asyncio
@@ -495,11 +542,12 @@ class TestVersionConsistency:
         assert v and len(v.split(".")) == 3, f"Invalid manifest version: {v!r}"
 
     def test_diagnostics_version(self):
-        """diagnostics.py must embed the same version as manifest.json."""
+        """diagnostics must report the same version as manifest.json (read at runtime)."""
         v = self._manifest_version()
-        with open("custom_components/ws_core/diagnostics.py") as f:
-            content = f.read()
-        assert f'"{v}"' in content, f"diagnostics.py does not contain version {v!r}"
+        from custom_components.ws_core.diagnostics import _VERSION, _integration_version
+
+        assert _VERSION == v, f"diagnostics _VERSION {_VERSION!r} != manifest {v!r}"
+        assert _integration_version() == v
 
     def test_pyproject_version(self):
         """pyproject.toml must match manifest.json version."""

--- a/tests/test_sensor_platform.py
+++ b/tests/test_sensor_platform.py
@@ -44,3 +44,54 @@ def test_wind_direction_classes_resolve_without_crashing():
     )
     # state class always falls back to a real member, never missing.
     assert isinstance(sensor._MEASUREMENT_ANGLE_STATE_CLASS, SensorStateClass)
+
+
+def _make_temp_sensor(prefix="ws"):
+    from unittest.mock import MagicMock
+
+    from custom_components.ws_core.const import KEY_NORM_TEMP_C
+    from custom_components.ws_core.sensor import SENSORS, WSSensor
+
+    desc = next(s for s in SENSORS if s.key == KEY_NORM_TEMP_C)
+    coord = MagicMock()
+    entry = MagicMock()
+    entry.entry_id = "entry_1"
+    return WSSensor(coord, entry, desc, prefix)
+
+
+def test_fresh_install_entity_id_uses_prefix():
+    """Fresh installs must still get sensor.{prefix}_{key} via suggested_object_id."""
+    s = _make_temp_sensor(prefix="ws")
+    # _slug_for_key maps the normalized temperature key to "temperature".
+    assert s._attr_suggested_object_id == "ws_temperature"
+
+    s2 = _make_temp_sensor(prefix="home")
+    assert s2._attr_suggested_object_id == "home_temperature"
+
+
+def test_added_to_hass_does_not_revert_user_rename():
+    """A user-renamed entity_id must survive async_added_to_hass (restart)."""
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from custom_components.ws_core.sensor import WSSensor
+
+    s = _make_temp_sensor()
+    # Simulate a user who renamed the entity away from the default.
+    s.entity_id = "sensor.my_outdoor_temperature"
+    s.hass = MagicMock()
+
+    reg = MagicMock()
+    with (
+        patch(
+            "homeassistant.helpers.update_coordinator.CoordinatorEntity.async_added_to_hass",
+            new=AsyncMock(),
+        ),
+        patch.object(WSSensor, "async_get_last_state", new=AsyncMock(return_value=None)),
+        patch("homeassistant.helpers.entity_registry.async_get", return_value=reg),
+    ):
+        asyncio.run(s.async_added_to_hass())
+
+    # The old behaviour force-renamed the entity back to sensor.ws_temperature.
+    reg.async_update_entity.assert_not_called()
+    assert s.entity_id == "sensor.my_outdoor_temperature"


### PR DESCRIPTION
## Release 2.6.2 - security, correctness, and blueprint fixes

Under-the-hood release. No new user-facing features; all items are bug or
security fixes plus one meteorological correctness change. Ships as a single
patch release.

### Security
- **Diagnostics no longer leak credentials.** The diagnostics export previously
  included full `entry.data`/`entry.options`, exposing forecast and upload-network
  API keys, passwords, and passcodes in a file users are told to attach to bug
  reports. All credential-like and location fields (including nested per-network
  blocks) are now redacted. Users who shared an earlier export should rotate keys.

### Fixed
- **User-renamed entities are no longer reverted on restart.** Entity ids are set
  once at creation (fresh installs still get `sensor.ws_*`) and then left to the user.
- **Blueprint cooldowns now work.** Inputs used inside Jinja are mapped into
  `variables:`; the storm and fire-danger alerts gained their missing cooldown
  condition (`cooldown_hours` previously did nothing).
- **Penman-Monteith ET0 uses the real site latitude** instead of a hardcoded 37 N.
- **FWI is correct in the Southern Hemisphere** (day-length tables were N-only).
- **Timezone-correct time handling** (`dt_util.now()` in the classifier and weather
  forecast alignment).
- **Docs/badge**: `validate.yaml` -> `validate.yml`, stale versions, and the false
  "24h windows reset on restart" claim.

### Changed
- **Sea-level pressure uses a 12h mean temperature** (WMO) instead of the
  instantaneous reading, removing a diurnal wave that also fed the Zambretti
  forecast and rain probability. Falls back to instantaneous until ~1h of history
  exists. MSLP/ET0/FWI values may shift slightly vs earlier versions - a correctness
  improvement, documented in the changelog.

### Docs / meta
- README Data & Privacy egress section, uninstall steps, fire/ET0 guidance;
  documented forecast source-priority/fusion; added root `CONTRIBUTING.md` and
  `SECURITY.md`; LICENSE author; `integration_type`; regenerated entity map;
  bumped to 2.6.2.

### Compatibility
No breaking changes: entity ids, `unique_id`s, config schema, and
`device_class`/`state_class`/units are all unchanged; new function params are
optional with defaults. Behavior changes (MSLP/ET0/FWI value shifts, working
blueprint cooldowns, non-reverting entity ids, redacted diagnostics) are intentional
and documented.

### Validation
276 tests pass (+8 new regression tests), ruff check + format clean, all dashboards
and all 10 blueprints validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
