### PR TITLE
Release 2.6.4: weekly/monthly temp & gust extremes, translation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Weather Station Core are documented here.
 
+## [2.6.4] - 2026-07-29
+
+### Added
+
+- **Weekly and monthly temperature extremes (issue #127):** `sensor.ws_temperature_high_week` / `sensor.ws_temperature_low_week` (reset on the ISO week boundary, Monday, exposing a `week_ref` attribute) and `sensor.ws_temperature_high_month` / `sensor.ws_temperature_low_month` (reset on the 1st, exposing a `month_ref` attribute). Same pipeline, restore behaviour, and restart-persistence as the existing 24h/yearly/all-time temperature extreme sensors.
+- **Monthly, yearly and all-time wind gust max (issue #127):** `sensor.ws_wind_gust_max_month`, `sensor.ws_wind_gust_max_year` (each reset on their period boundary, exposing a `month_ref` / `year_ref` attribute) and `sensor.ws_wind_gust_max_all_time` (never resets). Complements the existing `sensor.ws_wind_gust_max_24h`.
+
+### Fixed
+
+- **French translation for yearly/all-time temperature sensors:** `fr.json` was missing the names added in 2.6.3 for `sensor.ws_temperature_high_year` / `_low_year` / `_high_all_time` / `_low_all_time`, so those four sensors fell back to their English translation key on a French install. Thanks to @Benjamin45590 (#126).
+- **Named indoor room sensors are now translatable (issue #128):** the per-room indoor temperature-delta, humidity, CO₂ and comfort sensors (added in 2.6.0) had their display name hardcoded in English (e.g. `"Humidity - {room}"`), bypassing Home Assistant's translation system entirely. They now use a `{room_name}` translation placeholder so their label follows the configured language, matching every other sensor in the integration.
+
 ## [2.6.3] - 2026-07-27
 
 ### Added

--- a/custom_components/ws_core/const.py
+++ b/custom_components/ws_core/const.py
@@ -229,6 +229,22 @@ KEY_TEMP_YEAR_REF = "temp_year_ref"
 KEY_TEMP_HIGH_ALL_TIME = "temp_high_all_time"
 KEY_TEMP_LOW_ALL_TIME = "temp_low_all_time"
 
+# Keys for WEEKLY / MONTHLY TEMPERATURE EXTREMES (issue #127)
+# Weekly resets on the ISO week boundary (Mon), monthly on the 1st.
+KEY_TEMP_HIGH_WEEK = "temp_high_week"
+KEY_TEMP_LOW_WEEK = "temp_low_week"
+KEY_TEMP_WEEK_REF = "temp_week_ref"
+KEY_TEMP_HIGH_MONTH = "temp_high_month"
+KEY_TEMP_LOW_MONTH = "temp_low_month"
+KEY_TEMP_MONTH_REF = "temp_month_ref"
+
+# Keys for MONTHLY / YEARLY / ALL-TIME WIND GUST MAX (issue #127)
+KEY_WIND_GUST_MAX_MONTH = "wind_gust_max_month"
+KEY_WIND_GUST_MONTH_REF = "wind_gust_month_ref"
+KEY_WIND_GUST_MAX_YEAR = "wind_gust_max_year"
+KEY_WIND_GUST_YEAR_REF = "wind_gust_year_ref"
+KEY_WIND_GUST_MAX_ALL_TIME = "wind_gust_max_all_time"
+
 # Keys for DISPLAY/FORMAT SENSORS
 KEY_UV_LEVEL_DISPLAY = "uv_level_display"
 KEY_HUMIDITY_LEVEL_DISPLAY = "humidity_level_display"

--- a/custom_components/ws_core/coordinator.py
+++ b/custom_components/ws_core/coordinator.py
@@ -461,10 +461,16 @@ from .const import (
     KEY_TEMP_DISPLAY,
     KEY_TEMP_HIGH_24H,
     KEY_TEMP_HIGH_ALL_TIME,
+    KEY_TEMP_HIGH_MONTH,
+    KEY_TEMP_HIGH_WEEK,
     KEY_TEMP_HIGH_YEAR,
     KEY_TEMP_LOW_24H,
     KEY_TEMP_LOW_ALL_TIME,
+    KEY_TEMP_LOW_MONTH,
+    KEY_TEMP_LOW_WEEK,
     KEY_TEMP_LOW_YEAR,
+    KEY_TEMP_MONTH_REF,
+    KEY_TEMP_WEEK_REF,
     KEY_TEMP_YEAR_REF,
     KEY_THSW_INDEX,
     KEY_THUNDERSTORM_RISK,
@@ -484,6 +490,11 @@ from .const import (
     KEY_WIND_DIR_VARIABILITY,
     KEY_WIND_GUST_FACTOR,
     KEY_WIND_GUST_MAX_24H,
+    KEY_WIND_GUST_MAX_ALL_TIME,
+    KEY_WIND_GUST_MAX_MONTH,
+    KEY_WIND_GUST_MAX_YEAR,
+    KEY_WIND_GUST_MONTH_REF,
+    KEY_WIND_GUST_YEAR_REF,
     KEY_WIND_QUADRANT,
     KEY_WIND_RUN_KM,
     KEY_WIND_RUN_MONTH_KM,
@@ -801,6 +812,21 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._temp_year_key: str = ""  # "YYYY"
         self._temp_high_all_time: float | None = None
         self._temp_low_all_time: float | None = None
+
+        # Weekly / monthly temperature extremes (issue #127).
+        self._temp_high_week: float | None = None
+        self._temp_low_week: float | None = None
+        self._temp_week_isoweek: str = ""  # "GGGG-Www"
+        self._temp_high_month: float | None = None
+        self._temp_low_month: float | None = None
+        self._temp_month_key: str = ""  # "YYYY-MM"
+
+        # Monthly / yearly / all-time wind gust max (issue #127).
+        self._gust_max_month: float | None = None
+        self._gust_month_key: str = ""  # "YYYY-MM"
+        self._gust_max_year: float | None = None
+        self._gust_year_key: str = ""  # "YYYY"
+        self._gust_max_all_time: float | None = None
 
         # v2.0 max rain rate over rolling 24h window
         self._rain_rate_history_24h: deque = deque()
@@ -1652,6 +1678,7 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # raw reading before it feeds the 24h rolling window below, so these
         # track every accepted reading rather than the 24h-windowed subset.
         self._update_temp_year_all_time(data, tc)
+        self._update_temp_week_month(data, tc)
 
         # 24h rolling stats
         if tc is not None:
@@ -1764,6 +1791,46 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         data[KEY_TEMP_HIGH_ALL_TIME] = round(self._temp_high_all_time, 1)
         data[KEY_TEMP_LOW_ALL_TIME] = round(self._temp_low_all_time, 1)
 
+    def _update_temp_week_month(self, data: dict, tc: float | None) -> None:
+        """Update this-week and this-month temperature high/low extremes (issue #127).
+
+        Weekly extremes reset on the ISO week boundary (Monday), exposed as
+        the ``week_ref`` attribute. Monthly extremes reset on the 1st,
+        exposed as ``month_ref``.
+        """
+        if tc is None:
+            return
+        temp = float(tc)
+        now_local = dt_util.now()
+        iso_week = now_local.strftime("%G-W%V")
+        month_key = now_local.strftime("%Y-%m")
+
+        if iso_week != self._temp_week_isoweek:
+            self._temp_high_week = temp
+            self._temp_low_week = temp
+            self._temp_week_isoweek = iso_week
+        else:
+            if self._temp_high_week is None or temp > self._temp_high_week:
+                self._temp_high_week = temp
+            if self._temp_low_week is None or temp < self._temp_low_week:
+                self._temp_low_week = temp
+        data[KEY_TEMP_HIGH_WEEK] = round(self._temp_high_week, 1)
+        data[KEY_TEMP_LOW_WEEK] = round(self._temp_low_week, 1)
+        data[KEY_TEMP_WEEK_REF] = self._temp_week_isoweek
+
+        if month_key != self._temp_month_key:
+            self._temp_high_month = temp
+            self._temp_low_month = temp
+            self._temp_month_key = month_key
+        else:
+            if self._temp_high_month is None or temp > self._temp_high_month:
+                self._temp_high_month = temp
+            if self._temp_low_month is None or temp < self._temp_low_month:
+                self._temp_low_month = temp
+        data[KEY_TEMP_HIGH_MONTH] = round(self._temp_high_month, 1)
+        data[KEY_TEMP_LOW_MONTH] = round(self._temp_low_month, 1)
+        data[KEY_TEMP_MONTH_REF] = self._temp_month_key
+
     def _compute_derived_pressure(
         self, data: dict, now: Any, tc: float | None, pressure_hpa: float | None, rh: float | None
     ) -> tuple[float, float]:
@@ -1873,6 +1940,9 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if gust_vals:
                 data[KEY_WIND_GUST_MAX_24H] = round(max(gust_vals), 1)
 
+        # Monthly / yearly / all-time gust max (issue #127)
+        self._update_gust_month_year_all_time(data, gust_ms)
+
         # v2.0 wind gust factor
         if wind_ms is not None and gust_ms is not None:
             gf = calculate_wind_gust_factor(float(gust_ms), float(wind_ms))
@@ -1890,6 +1960,40 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             var = calculate_wind_direction_variability(dir_vals)
             if var is not None:
                 data[KEY_WIND_DIR_VARIABILITY] = var
+
+    def _update_gust_month_year_all_time(self, data: dict, gust_ms: float | None) -> None:
+        """Update monthly, yearly and all-time wind gust max (issue #127).
+
+        Monthly resets on the 1st, yearly on Jan 1st (each exposing a
+        ``*_ref`` attribute with the period key). All-time never resets
+        automatically.
+        """
+        if gust_ms is None:
+            return
+        gust = float(gust_ms)
+        now_local = dt_util.now()
+        month_key = now_local.strftime("%Y-%m")
+        year_key = now_local.strftime("%Y")
+
+        if month_key != self._gust_month_key:
+            self._gust_max_month = gust
+            self._gust_month_key = month_key
+        elif self._gust_max_month is None or gust > self._gust_max_month:
+            self._gust_max_month = gust
+        data[KEY_WIND_GUST_MAX_MONTH] = round(self._gust_max_month, 1)
+        data[KEY_WIND_GUST_MONTH_REF] = self._gust_month_key
+
+        if year_key != self._gust_year_key:
+            self._gust_max_year = gust
+            self._gust_year_key = year_key
+        elif self._gust_max_year is None or gust > self._gust_max_year:
+            self._gust_max_year = gust
+        data[KEY_WIND_GUST_MAX_YEAR] = round(self._gust_max_year, 1)
+        data[KEY_WIND_GUST_YEAR_REF] = self._gust_year_key
+
+        if self._gust_max_all_time is None or gust > self._gust_max_all_time:
+            self._gust_max_all_time = gust
+        data[KEY_WIND_GUST_MAX_ALL_TIME] = round(self._gust_max_all_time, 1)
 
     def _compute_derived_precipitation(self, data: dict, now: Any, rain_total_mm: float | None) -> float:
         """Rain rate (Kalman-filtered), rain display. Returns rain_rate (filtered)."""
@@ -3372,6 +3476,19 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "temp_year_key": self._temp_year_key,
             "temp_high_all_time": self._temp_high_all_time,
             "temp_low_all_time": self._temp_low_all_time,
+            # Weekly / monthly temperature extremes (issue #127)
+            "temp_high_week": self._temp_high_week,
+            "temp_low_week": self._temp_low_week,
+            "temp_week_isoweek": self._temp_week_isoweek,
+            "temp_high_month": self._temp_high_month,
+            "temp_low_month": self._temp_low_month,
+            "temp_month_key": self._temp_month_key,
+            # Monthly / yearly / all-time wind gust max (issue #127)
+            "gust_max_month": self._gust_max_month,
+            "gust_month_key": self._gust_month_key,
+            "gust_max_year": self._gust_max_year,
+            "gust_year_key": self._gust_year_key,
+            "gust_max_all_time": self._gust_max_all_time,
             # v2.0 degree-day accumulators (season totals must survive restarts)
             "hdd_today": self._hdd_today,
             "hdd_today_date": self._hdd_today_date,
@@ -3498,6 +3615,34 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._temp_high_all_time = float(th_all) if th_all is not None else None
         tl_all = data.get("temp_low_all_time")
         self._temp_low_all_time = float(tl_all) if tl_all is not None else None
+
+        # Weekly / monthly temperature extremes (issue #127): restore only
+        # when still the same period, mirroring the rain week/month restore.
+        if data.get("temp_week_isoweek") == iso_week:
+            th_week = data.get("temp_high_week")
+            self._temp_high_week = float(th_week) if th_week is not None else None
+            tl_week = data.get("temp_low_week")
+            self._temp_low_week = float(tl_week) if tl_week is not None else None
+            self._temp_week_isoweek = iso_week
+        if data.get("temp_month_key") == month_key:
+            th_month = data.get("temp_high_month")
+            self._temp_high_month = float(th_month) if th_month is not None else None
+            tl_month = data.get("temp_low_month")
+            self._temp_low_month = float(tl_month) if tl_month is not None else None
+            self._temp_month_key = month_key
+
+        # Monthly / yearly / all-time wind gust max (issue #127): monthly and
+        # yearly restore only within the same period; all-time is unconditional.
+        if data.get("gust_month_key") == month_key:
+            gm = data.get("gust_max_month")
+            self._gust_max_month = float(gm) if gm is not None else None
+            self._gust_month_key = month_key
+        if data.get("gust_year_key") == year_key:
+            gy = data.get("gust_max_year")
+            self._gust_max_year = float(gy) if gy is not None else None
+            self._gust_year_key = year_key
+        ga = data.get("gust_max_all_time")
+        self._gust_max_all_time = float(ga) if ga is not None else None
 
         # v2.0 degree days: 'today' values continue only within the same day;
         # 'season' totals are restored unconditionally (their own reset logic,

--- a/custom_components/ws_core/manifest.json
+++ b/custom_components/ws_core/manifest.json
@@ -14,5 +14,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/kmich/ha_ws_core/issues",
   "requirements": [],
-  "version": "2.6.3"
+  "version": "2.6.4"
 }

--- a/custom_components/ws_core/sensor.py
+++ b/custom_components/ws_core/sensor.py
@@ -219,10 +219,16 @@ from .const import (
     KEY_TEMP_DISPLAY,
     KEY_TEMP_HIGH_24H,
     KEY_TEMP_HIGH_ALL_TIME,
+    KEY_TEMP_HIGH_MONTH,
+    KEY_TEMP_HIGH_WEEK,
     KEY_TEMP_HIGH_YEAR,
     KEY_TEMP_LOW_24H,
     KEY_TEMP_LOW_ALL_TIME,
+    KEY_TEMP_LOW_MONTH,
+    KEY_TEMP_LOW_WEEK,
     KEY_TEMP_LOW_YEAR,
+    KEY_TEMP_MONTH_REF,
+    KEY_TEMP_WEEK_REF,
     KEY_TEMP_YEAR_REF,
     KEY_THSW_INDEX,
     KEY_THUNDERSTORM_RISK,
@@ -242,6 +248,11 @@ from .const import (
     KEY_WIND_DIR_VARIABILITY,
     KEY_WIND_GUST_FACTOR,
     KEY_WIND_GUST_MAX_24H,
+    KEY_WIND_GUST_MAX_ALL_TIME,
+    KEY_WIND_GUST_MAX_MONTH,
+    KEY_WIND_GUST_MAX_YEAR,
+    KEY_WIND_GUST_MONTH_REF,
+    KEY_WIND_GUST_YEAR_REF,
     KEY_WIND_QUADRANT,
     KEY_WIND_RUN_KM,
     KEY_WIND_RUN_MONTH_KM,
@@ -269,6 +280,7 @@ class WSSensorDescription:
     icon: str | None = None
     name: str | None = None
     translation_key: str | None = None
+    translation_placeholders: dict[str, str] | None = None
     native_unit: str | None = None
     state_class: SensorStateClass | None = None
     suggested_display_precision: int | None = None
@@ -1430,6 +1442,88 @@ SENSORS: list[WSSensorDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),
+    # =========================================================================
+    # WEEKLY / MONTHLY TEMPERATURE EXTREMES (issue #127)
+    # =========================================================================
+    WSSensorDescription(
+        key=KEY_TEMP_HIGH_WEEK,
+        translation_key="temperature_high_week",
+        name="WS Temperature High Week",
+        icon="mdi:thermometer-high",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit=UNIT_TEMP_C,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        attrs_fn=lambda d: {"week_ref": d.get(KEY_TEMP_WEEK_REF)},
+    ),
+    WSSensorDescription(
+        key=KEY_TEMP_LOW_WEEK,
+        translation_key="temperature_low_week",
+        name="WS Temperature Low Week",
+        icon="mdi:thermometer-low",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit=UNIT_TEMP_C,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        attrs_fn=lambda d: {"week_ref": d.get(KEY_TEMP_WEEK_REF)},
+    ),
+    WSSensorDescription(
+        key=KEY_TEMP_HIGH_MONTH,
+        translation_key="temperature_high_month",
+        name="WS Temperature High Month",
+        icon="mdi:thermometer-high",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit=UNIT_TEMP_C,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        attrs_fn=lambda d: {"month_ref": d.get(KEY_TEMP_MONTH_REF)},
+    ),
+    WSSensorDescription(
+        key=KEY_TEMP_LOW_MONTH,
+        translation_key="temperature_low_month",
+        name="WS Temperature Low Month",
+        icon="mdi:thermometer-low",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit=UNIT_TEMP_C,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        attrs_fn=lambda d: {"month_ref": d.get(KEY_TEMP_MONTH_REF)},
+    ),
+    # =========================================================================
+    # MONTHLY / YEARLY / ALL-TIME WIND GUST MAX (issue #127)
+    # =========================================================================
+    WSSensorDescription(
+        key=KEY_WIND_GUST_MAX_MONTH,
+        translation_key="wind_gust_max_month",
+        name="WS Wind Gust Max Month",
+        icon="mdi:weather-windy-variant",
+        device_class=SensorDeviceClass.WIND_SPEED,
+        native_unit=UNIT_WIND_MS,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit_group="wind",
+        attrs_fn=lambda d: {"month_ref": d.get(KEY_WIND_GUST_MONTH_REF)},
+    ),
+    WSSensorDescription(
+        key=KEY_WIND_GUST_MAX_YEAR,
+        translation_key="wind_gust_max_year",
+        name="WS Wind Gust Max Year",
+        icon="mdi:weather-windy-variant",
+        device_class=SensorDeviceClass.WIND_SPEED,
+        native_unit=UNIT_WIND_MS,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit_group="wind",
+        attrs_fn=lambda d: {"year_ref": d.get(KEY_WIND_GUST_YEAR_REF)},
+    ),
+    WSSensorDescription(
+        key=KEY_WIND_GUST_MAX_ALL_TIME,
+        translation_key="wind_gust_max_all_time",
+        name="WS Wind Gust Max All Time",
+        icon="mdi:weather-windy-variant",
+        device_class=SensorDeviceClass.WIND_SPEED,
+        native_unit=UNIT_WIND_MS,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit_group="wind",
+    ),
     # v2.0 Wind gust factor (gust / mean speed ratio)
     WSSensorDescription(
         key=KEY_WIND_GUST_FACTOR,
@@ -2533,6 +2627,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                         WSSensorDescription(
                             key=f"indoor_room_delta_{rid}",
                             name=f"Temp Delta - {name}",
+                            translation_key="indoor_room_delta",
+                            translation_placeholders={"room_name": name},
                             icon="mdi:thermometer-lines",
                             device_class=SensorDeviceClass.TEMPERATURE,
                             native_unit=UNIT_TEMP_C,
@@ -2555,6 +2651,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                         WSSensorDescription(
                             key=f"indoor_room_humidity_{rid}",
                             name=f"Humidity - {name}",
+                            translation_key="indoor_room_humidity",
+                            translation_placeholders={"room_name": name},
                             icon="mdi:water-percent",
                             device_class=SensorDeviceClass.HUMIDITY,
                             native_unit="%",
@@ -2576,6 +2674,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                         WSSensorDescription(
                             key=f"indoor_room_co2_{rid}",
                             name=f"CO₂ - {name}",
+                            translation_key="indoor_room_co2",
+                            translation_placeholders={"room_name": name},
                             icon="mdi:molecule-co2",
                             device_class=SensorDeviceClass.CO2,
                             native_unit="ppm",
@@ -2594,6 +2694,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                         WSSensorDescription(
                             key=f"indoor_room_comfort_{rid}",
                             name=f"Comfort - {name}",
+                            translation_key="indoor_room_comfort",
+                            translation_placeholders={"room_name": name},
                             icon="mdi:home-heart",
                             native_unit=None,
                             state_class=SensorStateClass.MEASUREMENT,
@@ -2655,6 +2757,15 @@ class WSSensor(RestoreEntity, CoordinatorEntity, SensorEntity):
         KEY_TEMP_LOW_YEAR,
         KEY_TEMP_HIGH_ALL_TIME,
         KEY_TEMP_LOW_ALL_TIME,
+        # v2.7 (issue #127): weekly / monthly temperature extremes
+        KEY_TEMP_HIGH_WEEK,
+        KEY_TEMP_LOW_WEEK,
+        KEY_TEMP_HIGH_MONTH,
+        KEY_TEMP_LOW_MONTH,
+        # v2.7 (issue #127): monthly / yearly / all-time gust max
+        KEY_WIND_GUST_MAX_MONTH,
+        KEY_WIND_GUST_MAX_YEAR,
+        KEY_WIND_GUST_MAX_ALL_TIME,
         KEY_RAIN_ACCUM_1H,
         KEY_RAIN_ACCUM_24H,
         # v1.3.0: removed cut keys (HDD/CDD/METAR) from restore set
@@ -2687,6 +2798,8 @@ class WSSensor(RestoreEntity, CoordinatorEntity, SensorEntity):
         self._attr_suggested_object_id = f"{prefix}_{self._slug_for_key(desc.key)}"
         if desc.translation_key:
             self._attr_translation_key = desc.translation_key
+            if desc.translation_placeholders:
+                self._attr_translation_placeholders = desc.translation_placeholders
         else:
             self._attr_name = desc.name
         self._attr_icon = desc.icon
@@ -2785,6 +2898,13 @@ class WSSensor(RestoreEntity, CoordinatorEntity, SensorEntity):
             KEY_TEMP_LOW_YEAR: "temperature_low_year",
             KEY_TEMP_HIGH_ALL_TIME: "temperature_high_all_time",
             KEY_TEMP_LOW_ALL_TIME: "temperature_low_all_time",
+            KEY_TEMP_HIGH_WEEK: "temperature_high_week",
+            KEY_TEMP_LOW_WEEK: "temperature_low_week",
+            KEY_TEMP_HIGH_MONTH: "temperature_high_month",
+            KEY_TEMP_LOW_MONTH: "temperature_low_month",
+            KEY_WIND_GUST_MAX_MONTH: "wind_gust_max_month",
+            KEY_WIND_GUST_MAX_YEAR: "wind_gust_max_year",
+            KEY_WIND_GUST_MAX_ALL_TIME: "wind_gust_max_all_time",
             KEY_HUMIDITY_LEVEL_DISPLAY: "humidity_level",
             KEY_UV_LEVEL_DISPLAY: "uv_level",
             KEY_TEMP_DISPLAY: "temperature_display",

--- a/custom_components/ws_core/strings.json
+++ b/custom_components/ws_core/strings.json
@@ -1281,6 +1281,27 @@
       "temperature_low_all_time": {
         "name": "Temperature Low (All-Time)"
       },
+      "temperature_high_week": {
+        "name": "Temperature High (Week)"
+      },
+      "temperature_low_week": {
+        "name": "Temperature Low (Week)"
+      },
+      "temperature_high_month": {
+        "name": "Temperature High (Month)"
+      },
+      "temperature_low_month": {
+        "name": "Temperature Low (Month)"
+      },
+      "wind_gust_max_month": {
+        "name": "Wind Gust Max (Month)"
+      },
+      "wind_gust_max_year": {
+        "name": "Wind Gust Max (Year)"
+      },
+      "wind_gust_max_all_time": {
+        "name": "Wind Gust Max (All-Time)"
+      },
       "humidity_level": {
         "name": "Humidity Level",
         "state": {
@@ -2219,6 +2240,18 @@
             "name": "Humidity (%)"
           }
         }
+      },
+      "indoor_room_delta": {
+        "name": "Temp Delta - {room_name}"
+      },
+      "indoor_room_humidity": {
+        "name": "Humidity - {room_name}"
+      },
+      "indoor_room_co2": {
+        "name": "CO₂ - {room_name}"
+      },
+      "indoor_room_comfort": {
+        "name": "Comfort - {room_name}"
       },
       "soil_moisture": {
         "name": "Soil Moisture",

--- a/custom_components/ws_core/translations/en.json
+++ b/custom_components/ws_core/translations/en.json
@@ -1281,6 +1281,27 @@
       "temperature_low_all_time": {
         "name": "Temperature Low (All-Time)"
       },
+      "temperature_high_week": {
+        "name": "Temperature High (Week)"
+      },
+      "temperature_low_week": {
+        "name": "Temperature Low (Week)"
+      },
+      "temperature_high_month": {
+        "name": "Temperature High (Month)"
+      },
+      "temperature_low_month": {
+        "name": "Temperature Low (Month)"
+      },
+      "wind_gust_max_month": {
+        "name": "Wind Gust Max (Month)"
+      },
+      "wind_gust_max_year": {
+        "name": "Wind Gust Max (Year)"
+      },
+      "wind_gust_max_all_time": {
+        "name": "Wind Gust Max (All-Time)"
+      },
       "humidity_level": {
         "name": "Humidity Level",
         "state": {
@@ -2219,6 +2240,18 @@
             "name": "Humidity (%)"
           }
         }
+      },
+      "indoor_room_delta": {
+        "name": "Temp Delta - {room_name}"
+      },
+      "indoor_room_humidity": {
+        "name": "Humidity - {room_name}"
+      },
+      "indoor_room_co2": {
+        "name": "CO₂ - {room_name}"
+      },
+      "indoor_room_comfort": {
+        "name": "Comfort - {room_name}"
       },
       "soil_moisture": {
         "name": "Soil Moisture",

--- a/custom_components/ws_core/translations/fr.json
+++ b/custom_components/ws_core/translations/fr.json
@@ -1303,6 +1303,39 @@
       "wind_gust_max_24h": {
         "name": "Rafale max (24h)"
       },
+      "temperature_high_year": {
+        "name": "Température max (Année)"
+      },
+      "temperature_low_year": {
+        "name": "Température min (Année)"
+      },
+      "temperature_high_all_time": {
+        "name": "Température max (record)"
+      },
+      "temperature_low_all_time": {
+        "name": "Température min (record)"
+      },
+      "temperature_high_week": {
+        "name": "Température max (semaine)"
+      },
+      "temperature_low_week": {
+        "name": "Température min (semaine)"
+      },
+      "temperature_high_month": {
+        "name": "Température max (mois)"
+      },
+      "temperature_low_month": {
+        "name": "Température min (mois)"
+      },
+      "wind_gust_max_month": {
+        "name": "Rafale max (mois)"
+      },
+      "wind_gust_max_year": {
+        "name": "Rafale max (année)"
+      },
+      "wind_gust_max_all_time": {
+        "name": "Rafale max (record)"
+      },
       "humidity_level": {
         "name": "Niveau d'humidité",
         "state": {
@@ -2242,6 +2275,18 @@
           }
         }
               },
+      "indoor_room_delta": {
+        "name": "Écart de température - {room_name}"
+      },
+      "indoor_room_humidity": {
+        "name": "Humidité - {room_name}"
+      },
+      "indoor_room_co2": {
+        "name": "CO₂ - {room_name}"
+      },
+      "indoor_room_comfort": {
+        "name": "Confort - {room_name}"
+      },
       "soil_moisture": {
         "name": "Humidité du sol",
         "state_attributes": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha_ws_core"
-version = "2.6.3"
+version = "2.6.4"
 description = "Weather Station Core - Home Assistant integration for personal weather stations"
 requires-python = ">=3.12"
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -32,12 +32,23 @@ from custom_components.ws_core.const import (
     KEY_PACKAGE_OK,
     KEY_SEA_LEVEL_PRESSURE_HPA,
     KEY_TEMP_HIGH_ALL_TIME,
+    KEY_TEMP_HIGH_MONTH,
+    KEY_TEMP_HIGH_WEEK,
     KEY_TEMP_HIGH_YEAR,
     KEY_TEMP_LOW_ALL_TIME,
+    KEY_TEMP_LOW_MONTH,
+    KEY_TEMP_LOW_WEEK,
     KEY_TEMP_LOW_YEAR,
+    KEY_TEMP_MONTH_REF,
+    KEY_TEMP_WEEK_REF,
     KEY_TEMP_YEAR_REF,
     KEY_WET_BULB_C,
     KEY_WIND_BEAUFORT,
+    KEY_WIND_GUST_MAX_ALL_TIME,
+    KEY_WIND_GUST_MAX_MONTH,
+    KEY_WIND_GUST_MAX_YEAR,
+    KEY_WIND_GUST_MONTH_REF,
+    KEY_WIND_GUST_YEAR_REF,
     KEY_WIND_QUADRANT,
     KEY_ZAMBRETTI_FORECAST,
     KEY_ZAMBRETTI_NUMBER,
@@ -182,6 +193,17 @@ def _make_coordinator(
     coord._temp_year_key = ""
     coord._temp_high_all_time = None
     coord._temp_low_all_time = None
+    coord._temp_high_week = None
+    coord._temp_low_week = None
+    coord._temp_week_isoweek = ""
+    coord._temp_high_month = None
+    coord._temp_low_month = None
+    coord._temp_month_key = ""
+    coord._gust_max_month = None
+    coord._gust_month_key = ""
+    coord._gust_max_year = None
+    coord._gust_year_key = ""
+    coord._gust_max_all_time = None
     coord._solar_energy_today_whm2 = 0.0
     coord._solar_energy_date = ""
     coord._solar_energy_last_ts = None
@@ -386,6 +408,130 @@ class TestTempYearAllTime:
         assert data == {}
         assert coord._temp_high_year is None
         assert coord._temp_high_all_time is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: Weekly / Monthly Temperature Extremes (issue #127)
+# ---------------------------------------------------------------------------
+
+
+class TestTempWeekMonth:
+    def test_first_reading_seeds_week_and_month(self):
+        coord = _make_coordinator()
+        data = {}
+        coord._update_temp_week_month(data, 18.0)
+        assert data[KEY_TEMP_HIGH_WEEK] == 18.0
+        assert data[KEY_TEMP_LOW_WEEK] == 18.0
+        assert data[KEY_TEMP_HIGH_MONTH] == 18.0
+        assert data[KEY_TEMP_LOW_MONTH] == 18.0
+        assert data[KEY_TEMP_WEEK_REF] == coord._temp_week_isoweek
+        assert data[KEY_TEMP_MONTH_REF] == coord._temp_month_key
+
+    def test_tracks_new_highs_and_lows(self):
+        coord = _make_coordinator()
+        for temp in (10.0, 25.0, -5.0, 12.0):
+            data = {}
+            coord._update_temp_week_month(data, temp)
+        assert data[KEY_TEMP_HIGH_WEEK] == 25.0
+        assert data[KEY_TEMP_LOW_WEEK] == -5.0
+        assert data[KEY_TEMP_HIGH_MONTH] == 25.0
+        assert data[KEY_TEMP_LOW_MONTH] == -5.0
+
+    def test_week_rollover_resets_week_but_not_month(self):
+        coord = _make_coordinator()
+        coord._temp_high_week = 30.0
+        coord._temp_low_week = -10.0
+        coord._temp_week_isoweek = "2020-W01"
+        coord._temp_high_month = 30.0
+        coord._temp_low_month = -10.0
+        coord._temp_month_key = dt_util.now().strftime("%Y-%m")
+
+        data = {}
+        coord._update_temp_week_month(data, 5.0)
+
+        assert data[KEY_TEMP_HIGH_WEEK] == 5.0
+        assert data[KEY_TEMP_LOW_WEEK] == 5.0
+        # Month key still matches, so month extremes are untouched by the week rollover.
+        assert data[KEY_TEMP_HIGH_MONTH] == 30.0
+        assert data[KEY_TEMP_LOW_MONTH] == -10.0
+
+    def test_month_rollover_resets_month(self):
+        coord = _make_coordinator()
+        coord._temp_high_month = 30.0
+        coord._temp_low_month = -10.0
+        coord._temp_month_key = "2020-01"
+
+        data = {}
+        coord._update_temp_week_month(data, 5.0)
+
+        current_month = dt_util.now().strftime("%Y-%m")
+        assert coord._temp_month_key == current_month
+        assert data[KEY_TEMP_HIGH_MONTH] == 5.0
+        assert data[KEY_TEMP_LOW_MONTH] == 5.0
+
+    def test_handles_none_gracefully(self):
+        coord = _make_coordinator()
+        data = {}
+        coord._update_temp_week_month(data, None)
+        assert data == {}
+        assert coord._temp_high_week is None
+        assert coord._temp_high_month is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: Monthly / Yearly / All-Time Wind Gust Max (issue #127)
+# ---------------------------------------------------------------------------
+
+
+class TestGustMonthYearAllTime:
+    def test_first_reading_seeds_all_periods(self):
+        coord = _make_coordinator()
+        data = {}
+        coord._update_gust_month_year_all_time(data, 8.0)
+        assert data[KEY_WIND_GUST_MAX_MONTH] == 8.0
+        assert data[KEY_WIND_GUST_MAX_YEAR] == 8.0
+        assert data[KEY_WIND_GUST_MAX_ALL_TIME] == 8.0
+        assert data[KEY_WIND_GUST_MONTH_REF] == coord._gust_month_key
+        assert data[KEY_WIND_GUST_YEAR_REF] == coord._gust_year_key
+
+    def test_tracks_new_max(self):
+        coord = _make_coordinator()
+        for gust in (5.0, 12.0, 3.0, 9.0):
+            data = {}
+            coord._update_gust_month_year_all_time(data, gust)
+        assert data[KEY_WIND_GUST_MAX_MONTH] == 12.0
+        assert data[KEY_WIND_GUST_MAX_YEAR] == 12.0
+        assert data[KEY_WIND_GUST_MAX_ALL_TIME] == 12.0
+
+    def test_month_rollover_resets_month_not_year_or_all_time(self):
+        coord = _make_coordinator()
+        coord._gust_max_month = 20.0
+        coord._gust_month_key = "2020-01"
+        coord._gust_max_year = 20.0
+        coord._gust_year_key = dt_util.now().strftime("%Y")
+        coord._gust_max_all_time = 25.0
+
+        data = {}
+        coord._update_gust_month_year_all_time(data, 4.0)
+
+        assert data[KEY_WIND_GUST_MAX_MONTH] == 4.0
+        assert data[KEY_WIND_GUST_MAX_YEAR] == 20.0
+        assert data[KEY_WIND_GUST_MAX_ALL_TIME] == 25.0
+
+    def test_all_time_never_resets(self):
+        coord = _make_coordinator()
+        data = {}
+        coord._update_gust_month_year_all_time(data, 40.0)
+        coord._update_gust_month_year_all_time(data, 2.0)
+        assert data[KEY_WIND_GUST_MAX_ALL_TIME] == 40.0
+
+    def test_handles_none_gracefully(self):
+        coord = _make_coordinator()
+        data = {}
+        coord._update_gust_month_year_all_time(data, None)
+        assert data == {}
+        assert coord._gust_max_month is None
+        assert coord._gust_max_all_time is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_history_persistence.py
+++ b/tests/test_history_persistence.py
@@ -53,6 +53,17 @@ def _coord():
     c._temp_year_key = ""
     c._temp_high_all_time = None
     c._temp_low_all_time = None
+    c._temp_high_week = None
+    c._temp_low_week = None
+    c._temp_week_isoweek = ""
+    c._temp_high_month = None
+    c._temp_low_month = None
+    c._temp_month_key = ""
+    c._gust_max_month = None
+    c._gust_month_key = ""
+    c._gust_max_year = None
+    c._gust_year_key = ""
+    c._gust_max_all_time = None
     c._hdd_today = 0.0
     c._hdd_today_date = ""
     c._hdd_today_samples = 0
@@ -215,3 +226,78 @@ class TestHistoryRoundTrip:
         assert dst._temp_year_key == ""
         assert dst._temp_high_all_time is None
         assert dst._temp_low_all_time is None
+
+    def test_temp_week_month_roundtrip(self):
+        """Weekly/monthly temperature extremes (issue #127) survive a restart when
+        the saved period key still matches the current period."""
+        src = _coord()
+        this_week = dt_util.now().strftime("%G-W%V")
+        this_month = dt_util.now().strftime("%Y-%m")
+        src._temp_high_week = 22.0
+        src._temp_low_week = 5.0
+        src._temp_week_isoweek = this_week
+        src._temp_high_month = 28.0
+        src._temp_low_month = -2.0
+        src._temp_month_key = this_month
+        blob = src._dump_history_state()
+
+        dst = _coord()
+        dst._restore_history_state(blob)
+        assert dst._temp_high_week == 22.0
+        assert dst._temp_low_week == 5.0
+        assert dst._temp_week_isoweek == this_week
+        assert dst._temp_high_month == 28.0
+        assert dst._temp_low_month == -2.0
+        assert dst._temp_month_key == this_month
+
+    def test_temp_week_month_not_restored_when_period_stale(self):
+        src = _coord()
+        src._temp_high_week = 22.0
+        src._temp_week_isoweek = "2020-W01"
+        src._temp_high_month = 28.0
+        src._temp_month_key = "2020-01"
+        blob = src._dump_history_state()
+
+        dst = _coord()
+        dst._restore_history_state(blob)
+        assert dst._temp_high_week is None
+        assert dst._temp_week_isoweek == ""
+        assert dst._temp_high_month is None
+        assert dst._temp_month_key == ""
+
+    def test_gust_month_year_all_time_roundtrip(self):
+        """Monthly/yearly/all-time gust max (issue #127) survive a restart."""
+        src = _coord()
+        this_month = dt_util.now().strftime("%Y-%m")
+        this_year = dt_util.now().strftime("%Y")
+        src._gust_max_month = 18.0
+        src._gust_month_key = this_month
+        src._gust_max_year = 24.0
+        src._gust_year_key = this_year
+        src._gust_max_all_time = 30.0
+        blob = src._dump_history_state()
+
+        dst = _coord()
+        dst._restore_history_state(blob)
+        assert dst._gust_max_month == 18.0
+        assert dst._gust_month_key == this_month
+        assert dst._gust_max_year == 24.0
+        assert dst._gust_year_key == this_year
+        assert dst._gust_max_all_time == 30.0
+
+    def test_gust_month_year_not_restored_when_period_stale_but_all_time_is(self):
+        src = _coord()
+        src._gust_max_month = 18.0
+        src._gust_month_key = "2020-01"
+        src._gust_max_year = 24.0
+        src._gust_year_key = "2020"
+        src._gust_max_all_time = 30.0
+        blob = src._dump_history_state()
+
+        dst = _coord()
+        dst._restore_history_state(blob)
+        assert dst._gust_max_month is None
+        assert dst._gust_month_key == ""
+        assert dst._gust_max_year is None
+        assert dst._gust_year_key == ""
+        assert dst._gust_max_all_time == 30.0


### PR DESCRIPTION
## Summary
- Adds `sensor.ws_temperature_high_week` / `_low_week` and `_high_month` / `_low_month` (issue #127), mirroring the existing 24h/yearly/all-time temperature extreme sensors.
- Adds `sensor.ws_wind_gust_max_month`, `_max_year`, and `_max_all_time` (issue #127), complementing the existing `wind_gust_max_24h`.
- Fixes `fr.json` missing names for the yearly/all-time temperature sensors added in 2.6.3 (#126, contributed by @Benjamin45590).
- Fixes named indoor room sensors (temp delta, humidity, CO2, comfort) having their display name hardcoded in English instead of using Home Assistant's translation system (#128).
- Bumps `manifest.json` / `pyproject.toml` to 2.6.4 and updates `CHANGELOG.md`.

Closes #127
Fixes #128
Fixes #126

## Test plan
- [x] `pytest tests/ -v` — 298 passed
- [x] `ruff check` / `ruff format --check` — clean
- [x] Validated all touched JSON translation files parse correctly
- [x] Added new unit tests for week/month temp extremes, gust month/year/all-time, and their restart-persistence round trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)