### PR TITLE
Release 2.6.7: fix altitude sensor decimal precision (issue #137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Weather Station Core are documented here.
 
+## [2.6.7] - 2026-08-17
+
+### Fixed
+
+- **Altitude sensors showed five decimal places (issue #137):** Cloud Base and Freezing Level are stored internally in metres and converted to the user's display unit (feet, if configured), but neither had a `suggested_display_precision`, so Home Assistant showed the raw converted float - e.g. `1234.56789 ft` instead of a clean whole number. Both now round to 0 decimal places for display, matching the other altitude-based sensors.
+
 ## [2.6.6] - 2026-08-11
 
 ### Fixed

--- a/custom_components/ws_core/manifest.json
+++ b/custom_components/ws_core/manifest.json
@@ -14,5 +14,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/kmich/ha_ws_core/issues",
   "requirements": [],
-  "version": "2.6.6"
+  "version": "2.6.7"
 }

--- a/custom_components/ws_core/sensor.py
+++ b/custom_components/ws_core/sensor.py
@@ -629,6 +629,7 @@ SENSORS: list[WSSensorDescription] = [
         icon="mdi:cloud-arrow-up",
         native_unit="m",
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
         unit_group="altitude",
         attrs_fn=lambda d: {
             "temp_c": d.get(KEY_NORM_TEMP_C),
@@ -647,6 +648,7 @@ SENSORS: list[WSSensorDescription] = [
         icon="mdi:snowflake",
         native_unit="m",
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
         unit_group="altitude",
         attrs_fn=lambda d: {
             "temp_c": d.get(KEY_NORM_TEMP_C),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha_ws_core"
-version = "2.6.6"
+version = "2.6.7"
 description = "Weather Station Core - Home Assistant integration for personal weather stations"
 requires-python = ">=3.12"
 


### PR DESCRIPTION
Fixes #137.

Cloud Base and Freezing Level are stored internally in metres and converted to the user's display unit (e.g. feet), but neither had a `suggested_display_precision`, so Home Assistant showed the raw converted float (e.g. `1234.56789 ft`) instead of a whole number. Both now round to 0 decimal places for display, matching the other altitude-based sensors.

- Bumped manifest.json and pyproject.toml to 2.6.7
- Updated CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)