### PR TITLE
Release 2.6.8: fix Rain Rate Max (24h) reset on HA restart (issue #139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Weather Station Core are documented here.
 
+## [2.6.8] - 2026-08-23
+
+### Fixed
+
+- **Rain Rate Max (24h) reset to zero on every HA restart (issue #139):** the rolling 24-hour rain-rate-max window is tracked in a plain in-memory deque, separate from the runtime history object that the integration already persists across restarts (used for the 24h temperature, gust, and rain-total windows). Because this deque was missing from that persistence pair entirely, it always started empty after a restart, so the very first coordinator update replaced the sensor's restored display value with a fresh single-sample "max" - effectively whatever the current rain rate happened to be, which reads as a reset to zero if it isn't actively raining. It's now saved and restored with the same 24h pruning as the other rolling windows. Thanks to @jake404 for the report (#139).
+
 ## [2.6.7] - 2026-08-17
 
 ### Fixed

--- a/custom_components/ws_core/coordinator.py
+++ b/custom_components/ws_core/coordinator.py
@@ -3485,6 +3485,7 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "temp_history_24h": _dq(rt.temp_history_24h),
             "gust_history_24h": _dq(rt.gust_history_24h),
             "rain_total_history_24h": _dq(rt.rain_total_history_24h),
+            "rain_rate_history_24h": _dq(self._rain_rate_history_24h),
             "pressure_history": [float(v) for v in rt.pressure_history],
             "pressure_history_ts": pts.isoformat() if hasattr(pts, "isoformat") else None,
             "rain_today_mm": self._rain_today_mm,
@@ -3577,6 +3578,13 @@ class WSStationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         rt.temp_history_24h = _load_dq("temp_history_24h")
         rt.gust_history_24h = _load_dq("gust_history_24h")
         rt.rain_total_history_24h = _load_dq("rain_total_history_24h")
+        # v2.6.8 (issue #139): rain rate max 24h lives in a plain instance deque
+        # rather than the runtime dataclass, and was missing from this restore
+        # pair entirely - it always started empty on restart, so the very first
+        # coordinator tick after restart replaced the sensor's restored display
+        # value with a fresh single-sample "max" (whatever the current rain
+        # rate happened to be), which looks like a reset to zero.
+        self._rain_rate_history_24h = _load_dq("rain_rate_history_24h")
 
         ph: deque = deque(maxlen=PRESSURE_HISTORY_SAMPLES)
         for v in data.get("pressure_history") or []:

--- a/custom_components/ws_core/manifest.json
+++ b/custom_components/ws_core/manifest.json
@@ -14,5 +14,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/kmich/ha_ws_core/issues",
   "requirements": [],
-  "version": "2.6.7"
+  "version": "2.6.8"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha_ws_core"
-version = "2.6.7"
+version = "2.6.8"
 description = "Weather Station Core - Home Assistant integration for personal weather stations"
 requires-python = ">=3.12"
 

--- a/tests/test_history_persistence.py
+++ b/tests/test_history_persistence.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import sys
+from collections import deque
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -80,6 +81,8 @@ def _coord():
     c._gdd_season_key = ""
     c._solar_energy_today_whm2 = 0.0
     c._solar_energy_date = ""
+    # v2.0 max rain rate over rolling 24h window (issue #139)
+    c._rain_rate_history_24h = deque()
     return c
 
 
@@ -93,6 +96,7 @@ class TestHistoryRoundTrip:
             src.runtime.temp_history_24h.append((ts, 20.0 + i))
             src.runtime.gust_history_24h.append((ts, 5.0 + i))
             src.runtime.rain_total_history_24h.append((ts, 100.0 + i))
+            src._rain_rate_history_24h.append((ts, 2.0 + i))
         src.runtime.pressure_history.extend([1010.0, 1011.0, 1012.0])
         src.runtime.pressure_history_ts = now
         src._rain_today_mm = 12.5
@@ -112,6 +116,7 @@ class TestHistoryRoundTrip:
 
         assert len(dst.runtime.temp_history_24h) == 3
         assert [round(v, 1) for _, v in dst.runtime.temp_history_24h] == [20.0, 21.0, 22.0]
+        assert [round(v, 1) for _, v in dst._rain_rate_history_24h] == [2.0, 3.0, 4.0]
         assert list(dst.runtime.pressure_history) == [1010.0, 1011.0, 1012.0]
         assert dst._rain_today_mm == 12.5
         assert dst._rain_today_last_total == 137.0
@@ -155,6 +160,36 @@ class TestHistoryRoundTrip:
         dst._restore_history_state(None)
         assert dst._rain_today_mm == 0.0
         assert len(dst.runtime.temp_history_24h) == 0
+        assert len(dst._rain_rate_history_24h) == 0
+
+    def test_rain_rate_max_24h_survives_restart(self):
+        """Regression test for issue #139: rain rate max 24h reset to zero on
+        every HA restart because its rolling-window deque lived only in memory
+        and was never included in the history store's dump/restore pair."""
+        src = _coord()
+        now = dt_util.utcnow()
+        # A rain burst peaked at 45 mm/h an hour ago; current rate has since
+        # dropped back to near zero.
+        src._rain_rate_history_24h.append((now - timedelta(hours=1), 45.0))
+        src._rain_rate_history_24h.append((now - timedelta(minutes=1), 0.2))
+        blob = src._dump_history_state()
+
+        dst = _coord()
+        dst._restore_history_state(blob)
+        rates = [v for _, v in dst._rain_rate_history_24h]
+        assert max(rates) == 45.0
+
+    def test_rain_rate_history_pruned_on_restore(self):
+        src = _coord()
+        now = dt_util.utcnow()
+        src._rain_rate_history_24h.append((now - timedelta(hours=30), 60.0))  # stale peak
+        src._rain_rate_history_24h.append((now - timedelta(hours=1), 5.0))
+        blob = src._dump_history_state()
+
+        dst = _coord()
+        dst._restore_history_state(blob)
+        rates = [v for _, v in dst._rain_rate_history_24h]
+        assert rates == [5.0]  # the 30h-old peak is outside the window
 
     def test_corrupt_entries_skipped(self):
         dst = _coord()


### PR DESCRIPTION
## Summary

Fixes #139 - Rain Rate Max (24h) was resetting to 0 (or a near-zero value) every time Home Assistant restarted.

## Root cause

The 24h rolling-window deque backing `sensor.ws_rain_rate_max_24h` (`_rain_rate_history_24h`) lived in a plain in-memory coordinator attribute. Unlike the sibling 24h windows (temperature, gust, rain total), it was never included in the coordinator's history-store dump/restore pair, so it always started empty after a restart.

The entity itself has restore-on-startup logic (`RestoreEntity`) that shows the last known value while data is "warming up" - but that fallback only applies while the coordinator reports `None` for the key. Since the (now-empty) deque got a fresh sample appended on the very first coordinator tick after restart, the coordinator immediately reported a real (but wrong) single-sample "max" - whatever the current rain rate happened to be - which overwrote the restored value and looked like a reset to zero.

## Fix

Persist and restore `_rain_rate_history_24h` the same way as `temp_history_24h`, `gust_history_24h`, and `rain_total_history_24h`: saved on clean shutdown and on the periodic crash-backstop save, restored on startup and pruned to the trailing 24h window.

Also bumped `manifest.json` / `pyproject.toml` to 2.6.8 and added a changelog entry, per this repo's release process.

## Testing

- Added two regression tests in `tests/test_history_persistence.py` covering the restart round-trip and 24h pruning of the rain-rate-max history.
- Extended the existing general round-trip test to include the new deque.
- Full suite: `313 passed`.
- `ruff check` / `ruff format --check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)